### PR TITLE
feature/US7482 Remove failing js test

### DIFF
--- a/apps/crossroads_interface/test/js/phoenixEventListener_test.js
+++ b/apps/crossroads_interface/test/js/phoenixEventListener_test.js
@@ -5,8 +5,4 @@ describe('phoenixEventListener()', function() {
     it("should do something", function() {
         expect(something()).toBe('something');
     });
-
-    it('demonstrates a failed test', function() {
-        expect(something()).toBe('nothing');
-    });
 });


### PR DESCRIPTION
This commit removes a test that was written to purposefully fail to
confirm that TeamCity failed the build on a failing js test within the
Phoenix framework.