### PR TITLE
DE3163 - Fix broken site title functionality

### DIFF
--- a/apps/crossroads_interface/web/templates/shared/angular_meta_tags.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/angular_meta_tags.html.eex
@@ -1,4 +1,4 @@
-<title><%= @meta_title %></title>
+<title ng-bind="meta.title"><%= @meta_title %></title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="description" content="<%= @meta_description %>">


### PR DESCRIPTION
This commit adds the ng-bind attribute to the head tag in the maestro
project. This will allow the title of the site to be dynamically updated
as individuals navigate around the legacy app.