### PR TITLE
feature/US6963 - Static Meta Data

### DIFF
--- a/apps/crossroads_interface/web/templates/layout/no_header_or_footer.html.eex
+++ b/apps/crossroads_interface/web/templates/layout/no_header_or_footer.html.eex
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" ng-app="crossroads">
   <head>
+    <%= render_existing CrossroadsInterface.SharedView, @meta_template, assigns %>
     <%= render CrossroadsInterface.SharedView, "common_head.html", assigns %>
     <%= render_existing @view_module, "head.html", assigns %>
-    <%= render_existing CrossroadsInterface.SharedView, @meta_template, assigns %>
   </head>
   <body class="crds-legacy-styles">
     <%= render @view_module, @view_template, assigns %>

--- a/apps/crossroads_interface/web/templates/layout/no_sidebar.html.eex
+++ b/apps/crossroads_interface/web/templates/layout/no_sidebar.html.eex
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" ng-app="crossroads">
   <head>
+    <%= render_existing CrossroadsInterface.SharedView, @meta_template, assigns %>
     <%= render CrossroadsInterface.SharedView, "common_head.html", assigns %>
     <%= render_existing @view_module, "head.html", assigns %>
-    <%= render_existing CrossroadsInterface.SharedView, @meta_template, assigns %>
   </head>
   <body>
     <div class="crds-styles">

--- a/apps/crossroads_interface/web/templates/layout/screen_width.html.eex
+++ b/apps/crossroads_interface/web/templates/layout/screen_width.html.eex
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" ng-app="crossroads">
   <head>
+    <%= render_existing CrossroadsInterface.SharedView, @meta_template, assigns %>
     <%= render CrossroadsInterface.SharedView, "common_head.html", assigns %>
     <%= render_existing @view_module, "head.html", assigns %>
-    <%= render_existing CrossroadsInterface.SharedView, @meta_template, assigns %>
   </head>
   <body>
     <div class="crds-styles">


### PR DESCRIPTION
Placing meta tags earlier in the HTML document.  '/' and '/Connect' HTML (extracted from browser) in an S3 bucket serving a static website had the desired inline preview within Slack.  Hoping that the cause for the missing inline preview is because of all of the <link> and <script> elements in the <head> appearing before the <meta> tags, and that timing was a potential issue.