### PR TITLE
DE3185 Update package.json shared-header version

### DIFF
--- a/apps/crossroads_interface/package.json
+++ b/apps/crossroads_interface/package.json
@@ -7,7 +7,7 @@
     },
     "repository": {},
     "dependencies": {
-        "crds-shared-header": "0.2.6",
+        "crds-shared-header": "0.2.7",
         "crds-styles": "crdschurch/crds-styles#development",
         "phoenix": "file:../../deps/phoenix",
         "phoenix_html": "file:../../deps/phoenix_html"


### PR DESCRIPTION
This updates package.json to use crds-shared-header version up to 0.2.7
to fix an issue with the crossroads logo that is displayed on /connect
routing back to /connect, instead of routing back to /