### PR TITLE
DE3316 Remove file that added duplicate head info

### DIFF
--- a/apps/crossroads_interface/web/templates/legacy/head.html.eex
+++ b/apps/crossroads_interface/web/templates/legacy/head.html.eex
@@ -1,1 +1,0 @@
-<%= render CrossroadsInterface.SharedView, "angular_meta_tags.html", assigns %>


### PR DESCRIPTION
This commit removes the head.html.eex file from
crossroads_interface/web/templates/legacy folder. This file was simply
pointing to the angular_meta_tags.html.eex file, which was already
getting included in the no_header_or_footer.html.eex layout, resulting
in the angular_meta_tags.html.eex partial getting included into the
resulting template twice.