### PR TITLE
PreRender.io should use cache / https

### DIFF
--- a/apache/apache_site.template.conf
+++ b/apache/apache_site.template.conf
@@ -51,24 +51,24 @@
 	# Only proxy the request to Prerender if it's a request for HTML
 	RewriteCond %{HTTP_USER_AGENT} baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator [NC,OR]
 	RewriteCond %{QUERY_STRING} _escaped_fragment_
-	RewriteRule ^(?!.*?(\.ico|\.svg|\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff))(index\.php|index\.html)?(.*) https://service.prerender.io/http://%{HTTP_HOST}/$3 [P,L]
+	RewriteRule ^(?!.*?(\.ico|\.svg|\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff))(index\.php|index\.html)?(.*) https://service.prerender.io/http://%{HTTP_HOST}$3 [P,L]
 
 
 	# Setup reverse proxy for gateway and content. This will 
 	# eliminate CORS preflight calls, helping performance of the site.
 	SSLProxyEngine on
 	
-	ProxyPass /proxy/gateway/ $CRDS_GATEWAY_SERVER_ENDPOINT retry=0
-	ProxyPassReverse /proxy/gateway/ $CRDS_GATEWAY_SERVER_ENDPOINT 
+	RewriteRule ^/?proxy/gateway/(.*) $CRDS_GATEWAY_SERVER_ENDPOINT/$1 [P]
+	ProxyPassReverse /proxy/gateway/ $CRDS_GATEWAY_SERVER_ENDPOINT
 
-	ProxyPass /proxy/services/ $CRDS_SERVICES_SERVER_ENDPOINT retry=0
+	RewriteRule ^/?proxy/services/(.*) $CRDS_SERVICES_SERVER_ENDPOINT/$1 [P]
 	ProxyPassReverse /proxy/services/ $CRDS_SERVICES_SERVER_ENDPOINT
 
-	ProxyPass /proxy/content/ $CRDS_CMS_SERVER_ENDPOINT retry=0
-	ProxyPassReverse /proxy/content/ $CRDS_CMS_SERVER_ENDPOINT 
+	RewriteRule ^/?proxy/content/(.*) $CRDS_CMS_SERVER_ENDPOINT/$1 [P]
+	ProxyPassReverse /proxy/content/ $CRDS_CMS_SERVER_ENDPOINT
 	
 	# Proxy to Phoenix
-	ProxyPass / https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/ retry=0
+	RewriteRule ^/(.*) https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/$1 [P,L]
 	ProxyPassReverse / https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/ 
 
 	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
@@ -110,13 +110,14 @@
 	# Setup reverse proxy for gateway and content. This will 
 	# eliminate CORS preflight calls, helping performance of the site.
 	SSLProxyEngine on
-	ProxyPass /proxy/gateway/ $CRDS_GATEWAY_SERVER_ENDPOINT retry=0
+	
+	RewriteRule ^/?proxy/gateway/(.*) $CRDS_GATEWAY_SERVER_ENDPOINT/$1 [P]
 	ProxyPassReverse /proxy/gateway/ $CRDS_GATEWAY_SERVER_ENDPOINT
 
-	ProxyPass /proxy/services/ $CRDS_SERVICES_SERVER_ENDPOINT retry=0
+	RewriteRule ^/?proxy/services/(.*) $CRDS_SERVICES_SERVER_ENDPOINT/$1 [P]
 	ProxyPassReverse /proxy/services/ $CRDS_SERVICES_SERVER_ENDPOINT
 
-	ProxyPass /proxy/content/ $CRDS_CMS_SERVER_ENDPOINT retry=0
+	RewriteRule ^/?proxy/content/(.*) $CRDS_CMS_SERVER_ENDPOINT/$1 [P]
 	ProxyPassReverse /proxy/content/ $CRDS_CMS_SERVER_ENDPOINT
 
 	# Prevent accessing .conf files
@@ -142,10 +143,10 @@
 	# Only proxy the request to Prerender if it's a request for HTML
 	RewriteCond %{HTTP_USER_AGENT} baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator [NC,OR]
 	RewriteCond %{QUERY_STRING} _escaped_fragment_
-	RewriteRule ^(?!.*?(\.ico|\.svg|\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff))(index\.php|index\.html)?(.*) https://service.prerender.io/http://%{HTTP_HOST}/$3 [P,L]
+	RewriteRule ^(?!.*?(\.ico|\.svg|\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff))(index\.php|index\.html)?(.*) https://service.prerender.io/http://%{HTTP_HOST}$3 [P,L]
 
 	# Proxy to Phoenix
-	ProxyPass / https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/ retry=0
+	RewriteRule ^/(.*) https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/$1 [P,L]
 	ProxyPassReverse / https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/ 
 
 	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,

--- a/apache/apache_site.template.conf
+++ b/apache/apache_site.template.conf
@@ -16,79 +16,9 @@
 </VirtualHost>
 
 <VirtualHost *:80>
-	# The ServerName directive sets the request scheme, hostname and port that
-	# the server uses to identify itself. This is used when creating
-	# redirection URLs. In the context of virtual hosts, the ServerName
-	# specifies what hostname must appear in the request's Host: header to
-	# match this virtual host. For the default virtual host (this file) this
-	# value is not decisive as it is used as a last resort host regardless.
-	# However, you must set it for any further virtual host explicitly.
-	# ServerName www.example.com
+	#Force redirect to HTTPS
 	ServerName $CRDS_SERVER_NAME
-	ServerAdmin webmaster@localhost
-	DocumentRoot $CRDS_WEBSITE_PATH
-
-	# Prevent accessing .conf files
-	<Files ~ "\.(conf)$">
-		Deny from all
-	</Files>
-
-	# Set request header for prerender.io account
-	RequestHeader set X-Prerender-Token "$CRDS_PRERENDER_IO_KEY"
-
-	RewriteEngine On
-
-	# Capture original request protocol
-	RewriteCond %{HTTPS}s ^(on(s)|offs)$
-	RewriteRule ^ - [env=proto:http%2]
-
-	# Redirect to https if https is not already on and call is not from prerender.io
-	RewriteCond %{HTTP_USER_AGENT} !Prerender
-	RewriteCond %{HTTPS} !=on
-	RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
-
-	# Redirect BOT request to prerender.io
-	# Only proxy the request to Prerender if it's a request for HTML
-	RewriteCond %{HTTP_USER_AGENT} baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator [NC,OR]
-	RewriteCond %{QUERY_STRING} _escaped_fragment_
-	RewriteRule ^(?!.*?(\.ico|\.svg|\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff))(index\.php|index\.html)?(.*) https://service.prerender.io/http://%{HTTP_HOST}$3 [P,L]
-
-
-	# Setup reverse proxy for gateway and content. This will 
-	# eliminate CORS preflight calls, helping performance of the site.
-	SSLProxyEngine on
-	
-	RewriteRule ^/?proxy/gateway/(.*) $CRDS_GATEWAY_SERVER_ENDPOINT/$1 [P]
-	ProxyPassReverse /proxy/gateway/ $CRDS_GATEWAY_SERVER_ENDPOINT
-
-	RewriteRule ^/?proxy/services/(.*) $CRDS_SERVICES_SERVER_ENDPOINT/$1 [P]
-	ProxyPassReverse /proxy/services/ $CRDS_SERVICES_SERVER_ENDPOINT
-
-	RewriteRule ^/?proxy/content/(.*) $CRDS_CMS_SERVER_ENDPOINT/$1 [P]
-	ProxyPassReverse /proxy/content/ $CRDS_CMS_SERVER_ENDPOINT
-	
-	# Proxy to Phoenix
-	RewriteRule ^/(.*) https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/$1 [P,L]
-	ProxyPassReverse / https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/ 
-
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	# LogLevel info ssl:warn
-	# LogLevel alert rewrite:trace3
-
-	ErrorLog $${APACHE_LOG_DIR}/$CRDS_SERVER_ALIAS-error.log 
-	CustomLog $${APACHE_LOG_DIR}/$CRDS_SERVER_ALIAS-access.log combined
-
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
-        
-
+	Redirect permanent / https://$CRDS_SERVER_NAME/
 </VirtualHost>
 
 <VirtualHost *:443>
@@ -143,7 +73,7 @@
 	# Only proxy the request to Prerender if it's a request for HTML
 	RewriteCond %{HTTP_USER_AGENT} baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator [NC,OR]
 	RewriteCond %{QUERY_STRING} _escaped_fragment_
-	RewriteRule ^(?!.*?(\.ico|\.svg|\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff))(index\.php|index\.html)?(.*) https://service.prerender.io/http://%{HTTP_HOST}$3 [P,L]
+	RewriteRule ^(?!.*?(\.ico|\.svg|\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff))(index\.php|index\.html)?(.*) https://service.prerender.io/https://%{HTTP_HOST}$3 [P,L]
 
 	# Proxy to Phoenix
 	RewriteRule ^/(.*) https://$MAESTRO_HOSTNAME:$MAESTRO_PORT/$1 [P,L]


### PR DESCRIPTION
This is built on top of the **Move all ProxyPass to RewriteRule so they don't race**  PR