### PR TITLE
Clean up the authorized plug

### DIFF
--- a/apps/crossroads_interface/config/config.exs
+++ b/apps/crossroads_interface/config/config.exs
@@ -13,16 +13,14 @@ defmodule ConfigHelper do
   defp get_maestro_name_extension do
     case System.get_env("MAESTRO_NAME_EXTENSION") do
       "" -> ""
-      nil -> ""
-      _ -> System.get_env("MAESTRO_NAME_EXTENSION")
+      ext -> ext
     end
   end
 
   defp get_environment do
     case System.get_env("CRDS_ENV") do
       "" -> ""
-      nil -> ""
-      _ -> "-" <> System.get_env("CRDS_ENV")
+      env -> "-" <> env 
     end
   end
 end

--- a/apps/crossroads_interface/config/test.exs
+++ b/apps/crossroads_interface/config/test.exs
@@ -5,7 +5,8 @@ config :crossroads_content,
   cms_server_endpoint: ""
 
 config :crossroads_interface,
-  gateway_server_endpoint: ""
+  gateway_server_endpoint: "",
+  cookie_prefix: "int"
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/apps/crossroads_interface/test/plugs/authorized_plug_test.exs
+++ b/apps/crossroads_interface/test/plugs/authorized_plug_test.exs
@@ -4,53 +4,41 @@ defmodule CrossroadsInterface.AuthorizedPlugTest do
   import Mock
 
   test "should call the gateway with the cookie value", %{conn: conn} do
-    Application.put_env(:crossroads_interface, :cookie_prefix, "int")
     with_mock CrossroadsInterface.ProxyHttp, [gateway_get: fn(_url, _headers) -> {:ok, %HTTPoison.Response{body: "", headers: "", status_code: 200}} end] do
-
      cookie_value = "@verySp#C!$lc)0k!e"
      conn = conn
         |> put_req_cookie("intsessionId", cookie_value)
         |> fetch_cookies()
         |> Authorized.call([])
-
       headers = [{"Authorization", cookie_value}]
       assert called CrossroadsInterface.ProxyHttp.gateway_get("api/authenticated", headers)
     end
   end
 
   test "should return true when a sessionId cookie is present and cookie is still valid", %{conn: conn} do
-    Application.put_env(:crossroads_interface, :cookie_prefix, "int")
     with_mock CrossroadsInterface.ProxyHttp, [gateway_get: fn(_url, _headers) -> {:ok, %HTTPoison.Response{body: "", headers: "", status_code: 200}} end] do
-
      conn = conn
         |> put_req_cookie("intsessionId", "@verySp#C!$lc)0k!e")
         |> fetch_cookies()
         |> Authorized.call([])
-
       assert conn.assigns.authorized == true
     end
   end
 
   test "should return false when a sessionId cookie is present, but cookie is invalid", %{conn: conn} do
-    Application.put_env(:crossroads_interface, :cookie_prefix, "int")
     with_mock CrossroadsInterface.ProxyHttp, [gateway_get: fn(_url, _headers) -> {:ok, %HTTPoison.Response{body: "", headers: "", status_code: 401}} end] do
-
       conn = conn
         |> put_req_cookie("intsessionId", "@verySp#C!$lc)0k!e")
         |> fetch_cookies()
         |> Authorized.call([])
-
       assert conn.assigns.authorized == false
     end
   end
 
   test "should return false when a sessionId cookie is not present", %{conn: conn} do
-    Application.put_env(:crossroads_interface, :cookie_prefix, "int")
-
     conn = conn
       |> fetch_cookies()
       |> Authorized.call([])
-
     assert conn.assigns.authorized == false
   end
 end


### PR DESCRIPTION
* match on the req_cookies in the parameters list
* set the :authorized param to the the value of `is_authorized?`
* match on the http call
* set the :cookie_prefix in the test config

I'd be happy to talk to any of these changes if there are any concerns