### PR TITLE
DE3651 - Loading Spinner Overlap

### DIFF
--- a/apps/crossroads_interface/web/static/css/main.scss
+++ b/apps/crossroads_interface/web/static/css/main.scss
@@ -14,6 +14,11 @@
       visibility: hidden;
   }
 
+  .app-container {
+    display: block;
+    min-height: 35vh;
+  }
+
   @import 'node_modules/crds-styles/assets/stylesheets/variables';
   @import 'node_modules/crds-styles/assets/stylesheets/overrides';
   @import 'node_modules/crds-styles/assets/stylesheets/functions';

--- a/apps/crossroads_interface/web/templates/crds_connect/app_root.html.eex
+++ b/apps/crossroads_interface/web/templates/crds_connect/app_root.html.eex
@@ -1,4 +1,4 @@
-    <app-root data-iframe-height>
+    <app-root data-iframe-height class="app-container">
       <div class="preloader-wrapper">
         <svg viewBox="0 0 102 101" class="preloader"><g fill="none" fill-rule="evenodd"><g transform="translate(1 1)" stroke-width="2"><ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse><path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path></g></g></svg>
       </div>


### PR DESCRIPTION
Original issue said:

> when I click on anything related to connect promotion on /live and connect page starts loading the spinner is spinning in the middle of footer

I just added a minimum height to the element that wraps the Connect application.