### PR TITLE
US8725 - Jumbotron Revisions

### DIFF
--- a/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
+++ b/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
@@ -1,36 +1,50 @@
-// Instantiate the global CRDS object.
 window['CRDS'] = window['CRDS'] || {};
 
-// Load the YouTube iframe API and insert into the page above the first script.
-var tag = document.createElement('script');
-    tag.src = "https://www.youtube.com/iframe_api";
-var firstScriptTag = document.getElementsByTagName('script')[0];
-    firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+CRDS.JumbotronVideoPlayer = function(jumbotronEl) {
+  this.jumbotronEl = jumbotronEl;
+  this.bgPlayerContainerEl = this.jumbotronEl.querySelector('.bg-video-player');
+  this.bgPlayerId = 'video-player-' + Math.random().toString(36).substr(2, 10);
 
-function onYouTubeIframeAPIReady() {
-  if (document.readyState != 'complete') {
-    setTimeout(onYouTubeIframeAPIReady, 100);
-    return true;
-  }
-}
+  this.bgPlayerEl = document.createElement('div');
+  this.bgPlayerEl.setAttribute('id', this.bgPlayerId);
+  this.bgPlayerContainerEl.appendChild(this.bgPlayerEl);
 
-CRDS.JumbotronVideoPlayer = function(options = {}) {
-  this.videoId = options.videoId;
-  this.playerId = options.playerId;
-  this.playerEl = document.getElementById(this.playerId);
-
-  if(!this.playerEl) {
-    return;
+  this.bgVideoId = this.jumbotronEl.getAttribute('data-video-id');
+  if (!this.bgVideoId) {
+    throw 'data-player-id is required on the jumbotron containing element.';
   }
 
-  this.playerContainerEl = this.playerEl.parentElement;
-  this.jumbotronEl = this.playerContainerEl.parentElement;
-  this.videoTrigger = this.jumbotronEl.querySelector('.video-trigger');
+  this.inlineVideoTrigger = this.jumbotronEl.querySelector('.inline-video-trigger');
+  this.inlineVideoId = this.inlineVideoTrigger.getAttribute('data-video-id') ||
+                       this.bgVideoId;
+
+  this.inlinePlayerContainerEl = this.jumbotronEl.querySelector('.inline-video-player');
+  this.inlinePlayerId = 'video-player-' + Math.random().toString(36).substr(2, 10);
+  this.inlinePlayerEl = document.createElement('div');
+  this.inlinePlayerEl.setAttribute('id', this.inlinePlayerId);
+  this.inlinePlayerContainerEl.appendChild(this.inlinePlayerEl);
+
+  this.bgPlayerVars = {
+    autoplay: 1,
+    controls: 0,
+    modestbranding: 1,
+    loop: 1,
+    playsinline: 1,
+    showinfo: 0,
+    playlist: this.bgVideoId // See: https://stackoverflow.com/a/25781957/2241124
+  };
+
+  this.inlinePlayerVars = {
+    autoplay: 0,
+    controls: 1,
+    modestbranding: 1,
+    showinfo: 0
+  };
 
   var preloader = document.createElement('div');
       preloader.classList.add('preloader-wrapper');
       preloader.innerHTML = '\
-        <svg viewBox="0 0 102 101" class="preloader"\>\
+        <svg viewBox="0 0 102 101" class="preloader preloader--top-right preloader--small"\>\
           <g fill="none" fill-rule="evenodd"\>\
             <g transform="translate(1 1)" stroke-width="2"\>\
               <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"\></ellipse\>\
@@ -38,50 +52,51 @@ CRDS.JumbotronVideoPlayer = function(options = {}) {
             </g\>\
           </g\>\
         </svg\>';
-
   this.jumbotronEl.prepend(preloader);
-
   this.preloaderContainerEl = this.jumbotronEl.querySelector('.preloader-wrapper');
   this.preloaderEl = this.jumbotronEl.querySelector('.preloader');
 
-  this.playerVars = {
-    autoplay: 1,
-    controls: 0,
-    modestbranding: 1,
-    loop: 1,
-    playsinline: 1,
-    showinfo: 0,
-    playlist: this.videoId // See: https://stackoverflow.com/a/25781957/2241124
-  }
+  var closeButton = document.createElement('a');
+      closeButton.classList.add('close-video');
+      closeButton.innerHTML = '\
+        <svg class="icon icon-2" viewBox="0 0 256 256"\>\
+          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#close"></use\>\
+        </svg\>';
+  this.inlinePlayerContainerEl.prepend(closeButton);
 
-  return this.initVideo();
+  this.inlineVideoTrigger.innerHTML = '\
+    <svg class="icon icon-5" viewBox="0 0 256 256"\>\
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#play-thin"></use\>\
+    </svg\>';
+
+  return this.initBgVideo();
 };
 
 CRDS.JumbotronVideoPlayer.prototype.constructor = CRDS.JumbotronVideoPlayer;
 
-CRDS.JumbotronVideoPlayer.prototype.initVideo = function() {
+CRDS.JumbotronVideoPlayer.prototype.initBgVideo = function() {
   var _this = this;
-  this.player = new YT.Player(this.playerId, {
-    videoId: this.videoId,
-    playerVars: this.playerVars,
+  this.bgPlayer = new YT.Player(this.bgPlayerId, {
+    videoId: this.bgVideoId,
+    playerVars: this.bgPlayerVars,
     events: {
       onReady: function(event) {
-        _this.onVideoReady(event);
+        _this.onBgVideoReady(event);
       },
       onStateChange: function(event) {
-        _this.onVideoStateChange(event);
+        _this.onBgVideoStateChange(event);
       }
     }
   });
   this.bindEvents();
 };
 
-CRDS.JumbotronVideoPlayer.prototype.onVideoReady = function(event) {
+CRDS.JumbotronVideoPlayer.prototype.onBgVideoReady = function(event) {
   this.resizePlayer();
   event.target.mute();
 };
 
-CRDS.JumbotronVideoPlayer.prototype.onVideoStateChange = function(event) {
+CRDS.JumbotronVideoPlayer.prototype.onBgVideoStateChange = function(event) {
   if (event.data == YT.PlayerState.PLAYING) {
     this.preloaderContainerEl.classList.add('loaded');
   } else {
@@ -94,9 +109,6 @@ CRDS.JumbotronVideoPlayer.prototype.resizePlayer = function() {
       height = this.jumbotronEl.offsetHeight,
       ratio = 16 / 9;
 
-  // Put the preloader in the middle of the container.
-  this.preloaderEl.style.top = ((height / 2) - 37.5) + 'px';
-
   // If the container is wider than the desired ratio ...
   if (width / height > ratio) {
     // The new width should be the width of the container,
@@ -105,12 +117,12 @@ CRDS.JumbotronVideoPlayer.prototype.resizePlayer = function() {
         newHeight = width / ratio;
 
     // Resize the player.
-    this.player.setSize(newWidth, newHeight);
+    this.bgPlayer.setSize(newWidth, newHeight);
 
     // The player's container should sit at the left,
     // and at half of its excess height.
-    this.playerContainerEl.style.left = 0;
-    this.playerContainerEl.style.top = -((newHeight - height) / 2) + 'px';
+    this.bgPlayerContainerEl.style.left = 0;
+    this.bgPlayerContainerEl.style.top = -((newHeight - height) / 2) + 'px';
   }
   // If the player is higher than the aspect ratio
   else {
@@ -120,12 +132,12 @@ CRDS.JumbotronVideoPlayer.prototype.resizePlayer = function() {
         newWidth = height * ratio;
 
     // Resize the player.
-    this.player.setSize(newWidth, newHeight);
+    this.bgPlayer.setSize(newWidth, newHeight);
 
     // The player's container should sit at the top,
     // and at half of its excess width.
-    this.playerContainerEl.style.top = 0;
-    this.playerContainerEl.style.left = -((newWidth - width) / 2) + 'px';
+    this.bgPlayerContainerEl.style.top = 0;
+    this.bgPlayerContainerEl.style.left = -((newWidth - width) / 2) + 'px';
   };
 };
 
@@ -136,20 +148,51 @@ CRDS.JumbotronVideoPlayer.prototype.bindEvents = function() {
     _this.resizePlayer();
   }, true);
 
-  this.videoTrigger.addEventListener('click', function(event) {
+  this.inlineVideoTrigger.addEventListener('click', function(event) {
     event.preventDefault();
-    _this.playForegroundVideo();
+    _this.playInlineVideo();
+  }, true);
+
+  var closeTrigger = this.inlinePlayerContainerEl.querySelector('.close-video');
+  closeTrigger.addEventListener('click', function(event) {
+    event.preventDefault();
+    _this.stopInlineVideo();
   }, true);
 };
 
-CRDS.JumbotronVideoPlayer.prototype.playForegroundVideo = function() {
-  var embedEl = document.createElement('iframe'),
-      src = 'https://www.youtube.com/embed/' + this.videoId + '?autoplay=1';
-
-  embedEl.setAttribute('class', 'video-full-size');
-  embedEl.setAttribute('src', src);
-  embedEl.setAttribute('frameborder', '0');
-
-  this.jumbotronEl.appendChild(embedEl);
+CRDS.JumbotronVideoPlayer.prototype.initInlineVideo = function() {
+  var _this = this;
+  this.inlinePlayer = new YT.Player(this.inlinePlayerId, {
+    videoId: this.inlineVideoId,
+    playerVars: this.inlinePlayerVars,
+    events: {
+      onReady: function(event) {
+        _this.playInlineVideo(event);
+      },
+      onStateChange: function(event) {
+        _this.onInlineVideoStateChange(event);
+      }
+    }
+  });
   return true;
+};
+
+CRDS.JumbotronVideoPlayer.prototype.playInlineVideo = function() {
+  if (!this.inlinePlayer) {
+    this.initInlineVideo();
+    return true;
+  }
+  this.inlinePlayerContainerEl.classList.add('active');
+  this.inlinePlayer.playVideo();
+};
+
+CRDS.JumbotronVideoPlayer.prototype.stopInlineVideo = function() {
+  this.inlinePlayerContainerEl.classList.remove('active');
+  this.inlinePlayer.stopVideo();
+};
+
+CRDS.JumbotronVideoPlayer.prototype.onInlineVideoStateChange = function(event) {
+  if (event.data == YT.PlayerState.ENDED) {
+    this.stopInlineVideo();
+  }
 };

--- a/apps/crossroads_interface/web/templates/cms_page/index.html.eex
+++ b/apps/crossroads_interface/web/templates/cms_page/index.html.eex
@@ -5,9 +5,17 @@
   new CRDS.CardCarousel('crds-home-location-cards');
 
   window.onload = function() {
-    new CRDS.JumbotronVideoPlayer({
-      videoId: 'EKgKp1NzEKU',
-      playerId: 'crds-bg-video'
-    });
-  }
+    initYouTube();
+  };
+
+  function initYouTube() {
+    if (!YT) {
+      setTimeout(initYouTube, 100);
+      return true;
+    }
+    var videoPlayers = document.querySelectorAll('.jumbotron.bg-video');
+    for (i = 0; i < videoPlayers.length; i++) {
+      new CRDS.JumbotronVideoPlayer(videoPlayers[i]);
+    }
+  };
 </script>

--- a/apps/crossroads_interface/web/templates/shared/common_body.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_body.html.eex
@@ -37,7 +37,7 @@
         })(document);
     </script>
     <script>
-        var env = window.env || {};        
+        var env = window.env || {};
         env.streamspotId = "<%= Application.get_env(:crossroads_interface, :streamspot_id) %>";
         env.streamspotKey = "<%= Application.get_env(:crossroads_interface, :streamspot_key) %>";
     </script>

--- a/apps/crossroads_interface/web/templates/shared/common_head.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_head.html.eex
@@ -39,7 +39,7 @@
     <link rel="shortcut icon" href="//crossroads-media.s3.amazonaws.com/images/favicon/favicon.ico">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
 
-    <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>"/> 
+    <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>"/>
 
     <style>
     @-webkit-keyframes spinnerRotate {
@@ -74,4 +74,6 @@
     <% end %>
 
     <base href="<%= @base_href %>">
+
+    <script src="//www.youtube.com/iframe_api"></script>
 


### PR DESCRIPTION
- `.container .jumbotron, .container-fluid .jumbotron { border-radius: 0; }`
- `.jumbotron { padding-top: 150px; padding-bottom: 150px; }` <-- (100px @ mobile) 
- `.jumbotron .small-heading { font-size: .85rem; line-height: 1; opacity: .8;}`
- `.jumbotron .title { margin: 1rem 0; }`
- `.jumbotron a.btn { margin: 1rem .25rem 0; }`
- Padding helper: Default to 48px. Then small (32px), large (80px), xlarge (112px). 
- Move loading spinner to top right corner of container; make smaller
- support different video for bkg & button
- both video links should be editable via CMS
- add close btn while video is playing 
- automatically go back to jumbotron once video ends

---

Corresponds with crdschurch/crds-styles#141 and crdschurch/crds-styleguide#163.
