### PR TITLE
US8429 - Block Level Buttons

### DIFF
--- a/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
+++ b/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
@@ -42,9 +42,9 @@ CRDS.JumbotronVideoPlayer = function(jumbotronEl) {
   };
 
   var preloader = document.createElement('div');
-      preloader.classList.add('preloader-wrapper');
+      preloader.classList.add('inline-preloader-wrapper');
       preloader.innerHTML = '\
-        <svg viewBox="0 0 102 101" class="preloader preloader--top-right preloader--small"\>\
+        <svg viewBox="0 0 102 101" class="inline-preloader inline-preloader--top-right inline-preloader--small"\>\
           <g fill="none" fill-rule="evenodd"\>\
             <g transform="translate(1 1)" stroke-width="2"\>\
               <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"\></ellipse\>\
@@ -53,8 +53,8 @@ CRDS.JumbotronVideoPlayer = function(jumbotronEl) {
           </g\>\
         </svg\>';
   this.jumbotronEl.prepend(preloader);
-  this.preloaderContainerEl = this.jumbotronEl.querySelector('.preloader-wrapper');
-  this.preloaderEl = this.jumbotronEl.querySelector('.preloader');
+  this.preloaderContainerEl = this.jumbotronEl.querySelector('.inline-preloader-wrapper');
+  this.preloaderEl = this.jumbotronEl.querySelector('.inline-preloader');
 
   var closeButton = document.createElement('a');
       closeButton.classList.add('close-video');


### PR DESCRIPTION
Given a developer viewing the DDK
When I view utility classes
Then i should see the .btn-block-mobile selector with a description of what it will do to help me make awesome buttons. 

Given a user viewing /connect
When I view a CTA throughout the application on mobile
Then it should be displayed 100% wide, block-level on my tiny screen

Given a user viewing /connect
When I view a CTA throughout the application on desktop
Then I should see inline-block elements that do not fill up 100% of my screen width. 

---

Corresponds with:

- crdschurch/crds-styles#142
- crdschurch/crds-styleguide#166
- crdschurch/crds-connect#411