### PR TITLE
US8888 - Jumbotron BG Image And Inline Video

### DIFF
--- a/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
+++ b/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
@@ -141,7 +141,8 @@ CRDS.JumbotronBgVideoPlayer.prototype.onVideoStateChange = function(event) {
 CRDS.JumbotronBgVideoPlayer.prototype.resizePlayer = function() {
   var width = this.jumbotronEl.offsetWidth,
       height = this.jumbotronEl.offsetHeight,
-      ratio = 16 / 9;
+      ratio = parseFloat(this.jumbotronEl.getAttribute('data-aspect-ratio')) ||
+              (16 / 9);
 
   // If the container is wider than the desired ratio ...
   if (width / height > ratio) {

--- a/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
+++ b/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
@@ -1,5 +1,7 @@
 window['CRDS'] = window['CRDS'] || {};
 
+// ---------------------------------------- JumbotronVideoPlayers
+
 CRDS.JumbotronVideoPlayers = function() {
   if(typeof YT == 'object') {
     this.init();
@@ -27,13 +29,17 @@ CRDS.JumbotronVideoPlayers.prototype.loadScript = function(url, callback) {
 }
 
 CRDS.JumbotronVideoPlayers.prototype.init = function() {
-  var videoPlayers = document.querySelectorAll('.jumbotron.bg-video');
-  for (var i = 0; i < videoPlayers.length; i++) {
-    new CRDS.JumbotronVideoPlayer(videoPlayers[i]);
+  var bgVideoPlayers = document.querySelectorAll('.jumbotron.bg-video');
+  for (var i = 0; i < bgVideoPlayers.length; i++) {
+    new CRDS.JumbotronBgVideoPlayer(bgVideoPlayers[i]);
+  }
+  var inlineVideoPlayers = document.querySelectorAll('.jumbotron.inline-video');
+  for (var i = 0; i < inlineVideoPlayers.length; i++) {
+    new CRDS.JumbotronInlineVideoPlayer(inlineVideoPlayers[i]);
   }
 }
 
-// --------------------------------------- #
+// ---------------------------------------- JumbotronBgVideoPlayer
 
 CRDS.JumbotronVideoPlayer = function(jumbotronEl) {
   this.jumbotronEl = jumbotronEl;
@@ -261,3 +267,5 @@ CRDS.JumbotronVideoPlayer.prototype.onInlineVideoStateChange = function(event) {
     this.stopInlineVideo();
   }
 };
+
+// ---------------------------------------- JumbotronInlineVideoPlayer


### PR DESCRIPTION
Given a user adding a jumbotron element to a page in the CMS
When the jumbotron contains a still background image
Then I should be able to invoke an inline video element from a CTA that replaces that jumbotron. 

Given a user viewing the jumbotron elements in the DDK
When reviewing the implementation details
Then I should see an example that plays an inline video on top of a still image.

---

Corresponds with crdschurch/crds-styles#163 and crdschurch/crds-styleguide#176.