### PR TITLE
DE3293 - Mobile Background Scroll

### DIFF
--- a/apps/crossroads_interface/web/templates/shared/common_body.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_body.html.eex
@@ -12,7 +12,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/svg4everybody/2.1.8/svg4everybody.min.js"></script>
     <script type="text/javascript" src="//cdn.jsdelivr.net/g/mutationobserver"></script>
-    <script src="//dz6ito7tas43n.cloudfront.net/documents/js/crds-shared-header-v0.4.1.min.js"></script>
+    <script src="//dz6ito7tas43n.cloudfront.net/documents/js/crds-shared-header-v0.4.2.min.js"></script>
 
     <script>
       imgix.onready(function() {


### PR DESCRIPTION
Bump shared header version reference.

**Do not merge until v0.4.2 of crds-shared-header has been released.** (See crdschurch/crds-shared-header#56 for details.)