### PR TITLE
DE3843 - Searchbar hotspot

### DIFF
--- a/apps/crossroads_interface/package.json
+++ b/apps/crossroads_interface/package.json
@@ -8,7 +8,7 @@
   "repository": {},
   "dependencies": {
     "crds-shared-header": "0.2.14",
-    "crds-styles": "0.9.0",
+    "crds-styles": "crdschurch/crds-styles#development",
     "phoenix": "file:../../deps/phoenix",
     "phoenix_html": "file:../../deps/phoenix_html"
   },


### PR DESCRIPTION
Update styles to development. 

Test 'X' in searchbar on Edge 15. Problem was the `svg` nested within a `button` doesn't work - so click the 'X' part (pixels).

Corresponds with crdschurch/crds-styles#165

---

In the Edge Browser, when I try to click the "X", it does not work all of the time. It seems like the Hot Spot is not quite in the right place as the "X" image