### PR TITLE
[HOTFIX] Connect Styles and Shared Header

### DIFF
--- a/apps/crossroads_interface/web/controllers/cms_page_controller.ex
+++ b/apps/crossroads_interface/web/controllers/cms_page_controller.ex
@@ -18,7 +18,7 @@ defmodule CrossroadsInterface.CmsPageController do
       |> assign(:body_class, body_class)
       |> assign(:crds_styles, crds_styles)
       |> render(CrossroadsInterface.CmsPageView, "index.html", %{ payload: page["content"],
-      "css_files": [ "/js/legacy/legacy.css" ]})
+      "css_files": [ "/css/app.css", "/js/legacy/legacy.css" ]})
   end
 
   defp getStylesClassFromPage(page) do

--- a/apps/crossroads_interface/web/controllers/crds_group_leader_controller.ex
+++ b/apps/crossroads_interface/web/controllers/crds_group_leader_controller.ex
@@ -21,6 +21,7 @@ defmodule CrossroadsInterface.CrdsGroupLeaderController do
         "/js/group_leader/vendor.bundle.js",
         "/js/group_leader/main.bundle.js"
       ], "css_files": [ 
+        "/css/app.css",
         "/js/legacy/legacy.css",
         "/js/group_leader/styles.bundle.css" 
       ]})

--- a/apps/crossroads_interface/web/controllers/crds_groups_controller.ex
+++ b/apps/crossroads_interface/web/controllers/crds_groups_controller.ex
@@ -21,6 +21,7 @@ defmodule CrossroadsInterface.CrdsGroupsController do
           "/js/crds_connect/vendor.js",
           "/js/crds_connect/app.js"
         ], "css_files": [
+          "/css/app.css", 
           "/js/legacy/legacy.css"
         ]})
   end

--- a/apps/crossroads_interface/web/controllers/crds_streaming_controller.ex
+++ b/apps/crossroads_interface/web/controllers/crds_streaming_controller.ex
@@ -22,6 +22,7 @@ defmodule CrossroadsInterface.CrdsStreamingController do
         "/js/crds_streaming/vendor.bundle.js",
         "/js/crds_streaming/main.bundle.js"
       ], "css_files": [ 
+        "/css/app.css",
         "/js/legacy/legacy.css",
         "/js/crds_streaming/styles.bundle.css" 
       ]})

--- a/apps/crossroads_interface/web/controllers/homepage_controller.ex
+++ b/apps/crossroads_interface/web/controllers/homepage_controller.ex
@@ -19,6 +19,7 @@ defmodule CrossroadsInterface.HomepageController do
     conn
     |> render(page,
               "css_files": [
+                "/css/app.css",
                 "/js/legacy/legacy.css"
               ])
   end

--- a/apps/crossroads_interface/web/controllers/legacy_controller.ex
+++ b/apps/crossroads_interface/web/controllers/legacy_controller.ex
@@ -62,6 +62,7 @@ defmodule CrossroadsInterface.LegacyController do
         "/js/legacy/misc.js",
         "/js/legacy/main.js"        
       ], "css_files": [
+       "/css/app.css",
        "/js/legacy/legacy.css"
       ], "base_href": "/"})
   end

--- a/apps/crossroads_interface/web/controllers/notfound_controller.ex
+++ b/apps/crossroads_interface/web/controllers/notfound_controller.ex
@@ -19,6 +19,7 @@ defmodule CrossroadsInterface.NotfoundController do
     |> put_status(404)
     |> render("404.html", %{ payload: page["content"],
       "css_files": [
+        "/css/app.css",
         "/js/legacy/legacy.css"
       ]
     })

--- a/apps/crossroads_interface/web/templates/shared/common_body.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_body.html.eex
@@ -12,7 +12,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/svg4everybody/2.1.8/svg4everybody.min.js"></script>
     <script type="text/javascript" src="//cdn.jsdelivr.net/g/mutationobserver"></script>
-    <script src="//dz6ito7tas43n.cloudfront.net/documents/js/crds-shared-header-v0.4.2.min.js"></script>
+    <script src="//dz6ito7tas43n.cloudfront.net/documents/js/crds-shared-header-v0.4.3.min.js"></script>
 
     <script>
       imgix.onready(function() {

--- a/apps/crossroads_interface/web/templates/shared/common_head.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_head.html.eex
@@ -69,7 +69,7 @@
 
     <%= if assigns[:css_files] do %>
         <%= for script_file <- @css_files do %>
-            <link href="<%= static_path(@conn, script_file)%>" type="text/css" rel="stylesheet"> </script>
+            <link href="<%= static_path(@conn, script_file)%>" type="text/css" rel="stylesheet" />
         <% end %>
     <% end %>
 

--- a/apps/crossroads_interface/web/templates/shared/common_head.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_head.html.eex
@@ -39,7 +39,7 @@
     <link rel="shortcut icon" href="//crossroads-media.s3.amazonaws.com/images/favicon/favicon.ico">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
 
-    <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>"/>
+    <!--<link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>"/>-->
 
     <style>
     @-webkit-keyframes spinnerRotate {

--- a/apps/crossroads_interface/web/templates/shared/common_head.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_head.html.eex
@@ -39,8 +39,6 @@
     <link rel="shortcut icon" href="//crossroads-media.s3.amazonaws.com/images/favicon/favicon.ico">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
 
-    <!--<link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>"/>-->
-
     <style>
     @-webkit-keyframes spinnerRotate {
       100% {


### PR DESCRIPTION
This PR does two things... 

1. Updates the shared header to it's latest version which resolves [DE3856: Click Area on Mobile Profile Nav](https://rally1.rallydev.com/#/66096747656d/detail/defect/133684844556).

2. Refactor's Maestro so that each micro-client controller defines which CSS files are included within the view. This should resolve a regression related to [the search bar on demo.crossroads.net/connect](https://files.slack.com/files-pri/T02C3F91X-F65SWCBHP/pasted_image_at_2017_07_10_12_31_pm.png).<br><br>_Root cause of this regression:_ `crds-connect` includes application styles ([crds-styles v0.8.0](https://github.com/crdschurch/crds-styles/releases/tag/v0.8.0)) within its bundled JS. Since `crds-maestro` is requiring `app.css` on all routes (which is built against [crds-styles v0.9.0](https://github.com/crdschurch/crds-styles/releases/tag/v0.9.0)) the styles on this element are not rendering properly. 

---

This PR is related to crdschurch/crds-angular#4200 and crdschurch/crds-shared-header#62