### PR TITLE
DE3838 - Suggested vid

### DIFF
--- a/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
+++ b/apps/crossroads_interface/web/static/js/home_page/jumbotron_video_player.js
@@ -75,6 +75,7 @@ CRDS.JumbotronBgVideoPlayer.prototype.init = function() {
     loop: 1,
     playsinline: 1,
     showinfo: 0,
+    iv_load_policy: 3,
     playlist: this.videoId // See: https://stackoverflow.com/a/25781957/2241124
   };
 


### PR DESCRIPTION
Add option to remove annotations, blocks the suggests vids section from popping up.

Could not recreate in DDK but added for the consistency of it. This did show up if I viewed homepage in incognito mode (I think a browser extension might've been a factor?) The suggested videos pop-up was small, located in the bottom-left corner and resizing the window made it more/less visible. Blocking annotation on videos did the trick in removing it.

Corresponds with crdschurch/crds-styleguide#182
(I feel like I hit PR bingo - both are 182!?!)

---
jumbotron video displaying "suggested" videos in lower left corner