### PR TITLE
DE3959 - Timepicker styling

### DIFF
--- a/apps/crossroads_interface/package.json
+++ b/apps/crossroads_interface/package.json
@@ -8,7 +8,7 @@
   "repository": {},
   "dependencies": {
     "crds-shared-header": "0.2.14",
-    "crds-styles": "0.10.0",
+    "crds-styles": "crdschurch/crds-styles#development",
     "phoenix": "file:../../deps/phoenix",
     "phoenix_html": "file:../../deps/phoenix_html"
   },

--- a/apps/crossroads_interface/web/static/css/main.scss
+++ b/apps/crossroads_interface/web/static/css/main.scss
@@ -35,6 +35,7 @@
   @import 'node_modules/crds-styles/assets/stylesheets/themes/modules';
   @import 'node_modules/crds-styles/assets/stylesheets/utilities/modules';
   @import 'node_modules/crds-styles/assets/stylesheets/vendors/datepicker';
+  @import 'node_modules/crds-styles/assets/stylesheets/vendors/timepicker';
   @import 'node_modules/crds-styles/assets/stylesheets/vendors/toast';
   @import './modules/legacy_footer';
   @import './pages/homepage';


### PR DESCRIPTION
Add timepicker styles to Maestro.
Corresponds with crdschurch/crds-styles#174 and crdschurch/crds-connect#518

---
Timepicker glyphicons and button styles are off.