### PR TITLE
US9304 - Groups Header Redux

### DIFF
--- a/apps/crossroads_interface/web/controllers/crds_groups_controller.ex
+++ b/apps/crossroads_interface/web/controllers/crds_groups_controller.ex
@@ -21,7 +21,6 @@ defmodule CrossroadsInterface.CrdsGroupsController do
           "/js/crds_connect/vendor.js",
           "/js/crds_connect/app.js"
         ], "css_files": [
-          "/css/app.css", 
           "/js/legacy/legacy.css"
         ]})
   end


### PR DESCRIPTION
Given a crds.net user 
When directed to the Groups
Then I should see the appropriate header for Groups within the Finder application

When directed to Connect
Then I should see the appropriate header for the Connect application

---

The biggest thing to check here is that the buttons work as expected when you are not on the map or list view.

---

Corresponds with crdschurch/crds-connect#528.