### PR TITLE
adding SVG fill for IE

### DIFF
--- a/apps/crossroads_interface/web/static/css/pages/_homepage.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_homepage.scss
@@ -118,8 +118,9 @@
     top: 1.25rem;
     right: 1.25rem;
     width: 1.25rem;
-    height: 1.25rem;  
-    color: white;
+    height: 1.25rem;
+    color: #ffffff;
+    fill: #ffffff;
     opacity: 1;
     pointer-events: all;
     


### PR DESCRIPTION
Close icon was not appearing on IE because no explicit fill color was set.