### PR TITLE
Update Styles + Change Countdown From ID -> Class

### DIFF
--- a/apps/crossroads_interface/test/js/homepage/countdown_test.js
+++ b/apps/crossroads_interface/test/js/homepage/countdown_test.js
@@ -120,7 +120,7 @@ describe('Countdown', () => {
   <div data-stream-upcoming='hide'>Not upcoming</div>
   <div data-stream-off='show'>Off</div>
   <div data-stream-off='hide'>Not off</div>
-  <section class="container" id="crossroads_countdown">
+  <section class="container crds-countdown" id="crossroads_countdown">
   <div class="time countdown" data-stream-live="hide"><span class="countdown-header">Join the live stream in...</span>
   <ul class="countdown-timer list-inline">
   <li class="countdown-days days"></li>

--- a/apps/crossroads_interface/web/static/css/pages/_homepage.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_homepage.scss
@@ -1,4 +1,5 @@
-#locations-filter-label, #happening-filter-label {
+#locations-filter-label,
+#happening-filter-label {
   .dropdown {
     float: right;
   }
@@ -97,6 +98,15 @@
   }
 }
 
+.jumbotron.bg-video .btn-white {
+  color: #333;
+  background-color: $cr-white;
+
+  &:hover {
+    background-color: $cr-gray-lighter;    
+  }
+}
+
 .jumbotron-overlay {
   position: absolute;
   top: 0;
@@ -152,6 +162,66 @@
       }
     }
 
+    .card-img-container {
+      position: relative;
+    }
+
+    .countdown-container,
+    .off-container,
+    .live-container {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: rgba(0,0,0,.6);
+      
+      .countdown-timer {
+        padding: 0;
+
+        li {
+          font-size: 1.875rem;
+        }
+      }
+    }
+
+    .off-container,
+    .live-container {
+      flex-direction: column;
+    }
+
+    .off-container {
+      h4 {
+        color: $cr-gray-lighter;
+      }
+
+      h3 {
+        font-size: 1.25rem;
+        color: $cr-white;
+
+        @media screen and (min-width: $screen-xs-min) {
+          font-size: 1.5rem;
+        }
+      }
+    }
+
+    .live-container {
+      background-color: rgba(24, 150, 214, .95);
+      cursor: pointer;
+
+      h4 {
+        font-size: 1.5rem;
+        color: $cr-white;
+      }
+
+      .icon {
+        height: 5rem;
+      }
+    }
+
     .divider {
       margin: .5rem 0 1rem;
       width: 20%;
@@ -159,7 +229,7 @@
       @media screen and (min-width: $screen-xs-min) {
         margin: 3rem;
         width: 1px;
-        height: 20%;
+        height: 10%;
       }
     }
 
@@ -178,6 +248,15 @@
 
       .card-block {
         margin-bottom: 0;
+        text-align: center;
+
+        @media screen and (min-width: $screen-xs-min) {
+          text-align: left;
+        }
+      }
+
+      .card-subtitle {
+        font-size: .875rem;
       }
 
       .card-link {

--- a/apps/crossroads_interface/web/static/js/home_page/countdown.js
+++ b/apps/crossroads_interface/web/static/js/home_page/countdown.js
@@ -25,7 +25,7 @@ CRDS.Countdown = class Countdown {
     this.streamspotId = window.env.streamspotId;
     this.streamspotKey = window.env.streamspotKey;
 
-    if ($('#crossroads_countdown').length) {
+    if ($('.crds-countdown').length) {
       Countdown.setLoadingStatus(true);
       this.getStreamspotStatus();
     }
@@ -133,7 +133,7 @@ CRDS.Countdown = class Countdown {
   }
 
   showCountdown() {
-    $('#crossroads_countdown').show();
+    $('.crds-countdown').show();
     Countdown.setLoadingStatus(false);
     this.setStreamStatus();
 
@@ -163,10 +163,10 @@ CRDS.Countdown = class Countdown {
         }
       }
     }
-    $('#crossroads_countdown .days').html(Countdown.padZero(this.days));
-    $('#crossroads_countdown .hours').html(Countdown.padZero(this.hours));
-    $('#crossroads_countdown .minutes').html(Countdown.padZero(this.minutes));
-    $('#crossroads_countdown .seconds').html(Countdown.padZero(this.seconds));
+    $('.crds-countdown .days').html(Countdown.padZero(this.days));
+    $('.crds-countdown .hours').html(Countdown.padZero(this.hours));
+    $('.crds-countdown .minutes').html(Countdown.padZero(this.minutes));
+    $('.crds-countdown .seconds').html(Countdown.padZero(this.seconds));
     if (this.hours < this.UPCOMING_DURATION && this.streamStatus !== 'upcoming') {
       this.setStreamStatus();
     }


### PR DESCRIPTION
This PR covers:
- creating a new button style for `Find A Location`
- styling for all three dynamic states of the upcoming section
- changing the countdown to look for the `crds-countdown` class instead of an ID for multiple countdowns running on a page concurrently

One thing to remember is that when this PR is merged the countdown on the HP will not work correctly unless the markup is changed.