### PR TITLE
DE4551 Fix time issue

### DIFF
--- a/apps/crossroads_interface/web/static/js/home_page/countdown.js
+++ b/apps/crossroads_interface/web/static/js/home_page/countdown.js
@@ -97,7 +97,7 @@ CRDS.Countdown = class Countdown {
 
   static get12HourTime(date) {
     let hours = date.getHours();
-    const minutes = (`0 ${date.getMinutes()}`).slice(-2);
+    const minutes = (`0${date.getMinutes()}`).slice(-2);
     let ampm = 'am';
 
     if (hours > 12) {

--- a/apps/crossroads_interface/web/static/js/home_page/countdown.js
+++ b/apps/crossroads_interface/web/static/js/home_page/countdown.js
@@ -83,6 +83,10 @@ CRDS.Countdown = class Countdown {
     );
   }
 
+  addOffsetTime(time) {
+    return new Date(time.getTime() + (this.STREAM_OFFSET * this.MS_PER_MINUTE));
+  }
+
   static getDayOfWeek(date) {
     // date comes in as YYYY-mm-dd format
     const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday',
@@ -93,7 +97,7 @@ CRDS.Countdown = class Countdown {
 
   static get12HourTime(date) {
     let hours = date.getHours();
-    const minutes = date.getMinutes();
+    const minutes = (`0 ${date.getMinutes()}`).slice(-2);
     let ampm = 'am';
 
     if (hours > 12) {
@@ -102,10 +106,6 @@ CRDS.Countdown = class Countdown {
     }
 
     return `${hours}:${minutes}${ampm}`;
-  }
-
-  addOffsetTime(time) {
-    return new Date(time.getTime() + (this.STREAM_OFFSET * this.MS_PER_MINUTE));
   }
 
   getStreamspotStatus() {


### PR DESCRIPTION
1. Contextualize any major architectural or UI changes in this PR.
This fixes a bug in which, when the minutes of the time was between 0
and 10, it would render a single digit to the web page, resulting in a
time like 10:7 am, instead of 10:07 am. This PR fixes that issue by
checking to see if the minutes of the start time with offset is less
than 10. If it is, it adds a '0' before that digit.

2. Do these changes belong here, or somewhere else?
Here

3. Does the code follow our coding standards and practices?
Yes

4. Has the code been linted?
Yes

5. Have you written tests for the code you wrote / changed?
N/A

6. Have you run your tests locally?
Yes

7. Is there anything that feels like a dirty hack? If so, have you worked with
someone to find another, cleaner way to accomplish the same thing?
Nope / N/A