### PR TITLE
DE4702: Fix z-index issues with overlay

### DIFF
--- a/apps/crossroads_interface/web/static/css/pages/_homepage.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_homepage.scss
@@ -165,7 +165,7 @@
   right: 0;
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.95);
-  z-index: 0;
+  z-index: -1;
   opacity: 0;
   -webkit-transition: 0.45s all ease-in-out;
   transition: 0.45s all ease-in-out;


### PR DESCRIPTION
Small `css` change to prevent users from accidentally clicking on hidden elements in the jumbotron overlay. Even though the elements were hidden visibly, they had the same `z-index` as the jumbotron content so clicks still happened.