### PR TITLE
DE4698: remove event.preventDefault from click tracking

### DIFF
--- a/apps/crossroads_interface/web/static/js/dataTracker.js
+++ b/apps/crossroads_interface/web/static/js/dataTracker.js
@@ -40,7 +40,6 @@ CRDS.DataTracker = class DataTracker {
   }
 
   handleSearch(event) {
-    event.preventDefault();
     const form = event.currentTarget;
     const searchInput = form.getElementsByTagName('input')[0];
     this.analytics.track('SearchRequested', {

--- a/apps/crossroads_interface/web/static/js/dataTracker.js
+++ b/apps/crossroads_interface/web/static/js/dataTracker.js
@@ -40,6 +40,7 @@ CRDS.DataTracker = class DataTracker {
   }
 
   handleSearch(event) {
+    event.preventDefault();
     const form = event.currentTarget;
     const searchInput = form.getElementsByTagName('input')[0];
     this.analytics.track('SearchRequested', {

--- a/apps/crossroads_interface/web/static/js/dataTracker.js
+++ b/apps/crossroads_interface/web/static/js/dataTracker.js
@@ -31,7 +31,6 @@ CRDS.DataTracker = class DataTracker {
   }
 
   handleClick(event) {
-    event.preventDefault();
     const el = event.currentTarget;
     this.analytics.track('ElementClicked', {
       Name: el.dataset.trackClick || el.id || 'Unnamed Click Event',


### PR DESCRIPTION
This line was inadvertently stopping `a` tags from following their `href` and, as @richardbarker pointed out, really didn't need to be in the function at all.