### PR TITLE
DE4731: Update UglifyJS

### DIFF
--- a/apps/crossroads_interface/package-lock.json
+++ b/apps/crossroads_interface/package-lock.json
@@ -72,6 +72,17 @@
       "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
       "dev": true
     },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -1846,6 +1857,16 @@
         "wrappy": "1.0.2"
       }
     },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
     "chalk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
@@ -2342,9 +2363,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crds-styles": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/crds-styles/-/crds-styles-1.2.0.tgz",
-      "integrity": "sha1-ki6XqpFLJHprZs0SoUx+bDM2pyE=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/crds-styles/-/crds-styles-1.3.0.tgz",
+      "integrity": "sha1-Ykzdu6cxQI4N3VG0/zamxvpS8Zw=",
       "requires": {
         "autoprefixer": "7.1.6",
         "bootstrap-sass": "3.3.7",
@@ -5804,6 +5825,11 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
+    },
     "js-base64": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
@@ -6086,6 +6112,12 @@
           "dev": true
         }
       }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -6375,6 +6407,12 @@
           "dev": true
         }
       }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -8101,6 +8139,15 @@
         "signal-exit": "3.0.2"
       }
     },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -9186,15 +9233,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "2.4.24",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-      "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+      "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
       "dev": true,
       "requires": {
         "async": "0.2.10",
-        "source-map": "0.1.34",
+        "source-map": "0.5.7",
         "uglify-to-browserify": "1.0.2",
-        "yargs": "3.5.4"
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "async": {
@@ -9209,14 +9256,22 @@
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true
         },
-        "source-map": {
-          "version": "0.1.34",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-          "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
           }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         },
         "wordwrap": {
           "version": "0.0.2",
@@ -9225,26 +9280,26 @@
           "dev": true
         },
         "yargs": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
             "camelcase": "1.2.1",
+            "cliui": "2.1.0",
             "decamelize": "1.2.0",
-            "window-size": "0.1.0",
-            "wordwrap": "0.0.2"
+            "window-size": "0.1.0"
           }
         }
       }
     },
     "uglify-js-brunch": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/uglify-js-brunch/-/uglify-js-brunch-1.7.8.tgz",
-      "integrity": "sha1-s23/vNGc/qJySNNHl+/+8a6dOmI=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/uglify-js-brunch/-/uglify-js-brunch-2.10.0.tgz",
+      "integrity": "sha1-YM0PtlKIegLOarzRWI3lXcw0bwU=",
       "dev": true,
       "requires": {
-        "uglify-js": "2.4.24"
+        "uglify-js": "2.6.4"
       }
     },
     "uglify-to-browserify": {

--- a/apps/crossroads_interface/package.json
+++ b/apps/crossroads_interface/package.json
@@ -35,7 +35,7 @@
     "karma-mocha-reporter": "^2.2.4",
     "karma-phantomjs-launcher": "^1.0.4",
     "sass-brunch": "^2.10.4",
-    "uglify-js-brunch": ">= 1.0 < 1.8",
+    "uglify-js-brunch": "^2.0.0",
     "watchify": "^3.9.0"
   }
 }


### PR DESCRIPTION
In order to take `uglify-js` to above `2.6.X` (so we can avoid vulnerability), I had to update `uglify-js-brunch` which has `uglify-js` as a dependancy.