### PR TITLE
DE4758 - Card Carousel Selector

### DIFF
--- a/apps/crossroads_interface/karma.conf.js
+++ b/apps/crossroads_interface/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
             'node_modules/jquery/dist/jquery.js',
             'node_modules/babel-polyfill/dist/polyfill.js',
             'node_modules/flickity/dist/flickity.pkgd.js',
-            'https://d1tmclqz61gqwd.cloudfront.net/javascripts/crds-card-carousel-v0.1.0.min.js',
+            'https://d1tmclqz61gqwd.cloudfront.net/javascripts/crds-card-carousel-v0.1.1.min.js',
             'test/**/*.js'
         ],
 

--- a/apps/crossroads_interface/test/js/home_page/distance_sorter_test.js
+++ b/apps/crossroads_interface/test/js/home_page/distance_sorter_test.js
@@ -18,8 +18,8 @@ describe('DistanceSorter', () => {
         </div>
       </form>
     </div>
-    <div class="card-deck carousel" data-carousel="mobile-scroll" data-carousel-id="carousel-a1kj76" data-filter-reset-label="All Locations">
-      <div class="feature-cards card-deck--expanded-layout" data-carousel="mobile-scroll" id="section-locations">
+    <div class="card-deck carousel" data-crds-carousel="mobile-scroll" data-carousel-id="carousel-a1kj76" data-filter-reset-label="All Locations">
+      <div class="feature-cards card-deck--expanded-layout" data-crds-carousel="mobile-scroll" id="section-locations">
         <div class="card" data-filter="Central Kentucky" data-location="Andover">
           <a class="block" href="/andover/"><img alt="Andover" class="card-img-top imgix-fluid" data-src="//crds-cms-uploads.imgix.net/Uploads/crossroads-andover.jpg?h=200&amp;max-h=200w=300&amp;&amp;crop=top&amp;fit=clamp&amp;auto=format" src="http://crds-cms-uploads.imgix.net/Uploads/crossroads-andover.jpg?auto=format&amp;crop=top&amp;fit=clamp&amp;ixjsv=2.2.3&amp;w=170"></a>
           <div class="card-block">

--- a/apps/crossroads_interface/web/templates/shared/common_body.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_body.html.eex
@@ -12,7 +12,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/svg4everybody/2.1.8/svg4everybody.min.js"></script>
     <script type="text/javascript" src="//cdn.jsdelivr.net/g/mutationobserver"></script>
-    <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-card-carousel-v0.1.0.min.js"></script>
+    <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-card-carousel-v0.1.1.min.js"></script>
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-shared-header-v0.5.5.min.js"></script>
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-status-message-v0.0.10.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.19/webcomponents-lite.js"></script>


### PR DESCRIPTION
Bump crds-card-carousel to 0.1.1.

See crdschurch/crds-card-carousel#4 for v0.1.1 changes to crds-card-carousel.

The main changes are that the default selector is `[data-crds-carousel]`, but still supports a custom data selector being passed.

@richardbarker: If you'd like this to be a hotfix, we can talk with Thundercats about getting it merged in. If not, we should be good to go since the carousels are being used on server side rendered pages.