### PR TITLE
DE4765: add explicit height to prevent alignment issues on jumbotron

### DIFF
--- a/apps/crossroads_interface/web/static/css/pages/_homepage.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_homepage.scss
@@ -228,6 +228,10 @@
         }
       }
 
+      .card-link-container {
+        height: 1.875rem;
+      }
+
       .card-link {
         display: none;
 


### PR DESCRIPTION
Basically this change makes sure that two sides are not out of balance by adding some height for the right side of the overlay which may or may not have a trailer link.