### PR TITLE
DE4788 Fix for extra case check on message

### DIFF
--- a/apps/crossroads_interface/test/views/cms_series_view_test.exs
+++ b/apps/crossroads_interface/test/views/cms_series_view_test.exs
@@ -4,6 +4,7 @@ defmodule CrossroadsInterface.CmsSeriesViewTest do
 
   @truthy_message %{"date" => "2017-11-25", "id" => 3883,
     "messageVideo" => %{
+      "source" => %{"my_key" => "my_value"},
       "still" => %{
         "filename" => "https://crds-cms-uploads.imgix.net/media/messages/stills/Screen-Shot-2017-11-25-at-7.56.07-PM.png",
       }

--- a/apps/crossroads_interface/web/views/cms_series_view.ex
+++ b/apps/crossroads_interface/web/views/cms_series_view.ex
@@ -3,8 +3,9 @@ defmodule CrossroadsInterface.CmsSeriesView do
 
   def message_valid?(message) do
     (message["title"] != nil) &&
-      (message["messageVideo"] != nil && message["messageVideo"] != %{})
-      && (get_in(message, ["messageVideo", "still", "filename"]) != nil)
+      (message["messageVideo"] != nil && message["messageVideo"] != %{}) &&
+      (get_in(message, ["messageVideo", "source"]) != nil) &&
+      (get_in(message, ["messageVideo", "still", "filename"]) != nil)
   end
 
   def get_message_still(message) do


### PR DESCRIPTION
Forgot a case to check against when deciding whether or not to display a message to the template.