### PR TITLE
DE4860: Fix date format and link entire thumbnail on new series page

### DIFF
--- a/apps/crossroads_interface/mix.exs
+++ b/apps/crossroads_interface/mix.exs
@@ -41,7 +41,8 @@ defmodule CrossroadsInterface.Mixfile do
      {:cowboy, "~> 1.0"},
      {:crossroads_content, in_umbrella: true, runtime: false},
      {:mix_test_watch, "~> 0.2", only: :dev},
-     {:mock, "~> 0.3.1", only: :test}]
+     {:mock, "~> 0.3.1", only: :test},
+     {:timex, "~> 3.0"}]
   end
 
   defp revision(default_version) do

--- a/apps/crossroads_interface/mix.lock
+++ b/apps/crossroads_interface/mix.lock
@@ -1,6 +1,7 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "cachex": {:hex, :cachex, "2.1.0", "fad49b4e78d11c6c314e75bd8c9408f5b78cb065c047442798caed10803ee3be", [:mix], [{:eternal, "~> 1.1", [hex: :eternal, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
@@ -32,4 +33,6 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
+  "timex": {:hex, :timex, "3.1.24", "d198ae9783ac807721cca0c5535384ebdf99da4976be8cefb9665a9262a1e9e3", [:mix], [{:combine, "~> 0.7", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.15", "d49241b0ca52c0b7354cb28ab87d290c30270194a436f9dc649bdc56ba97ceb7", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}

--- a/apps/crossroads_interface/web/templates/cms_series/individual_series.html.eex
+++ b/apps/crossroads_interface/web/templates/cms_series/individual_series.html.eex
@@ -13,10 +13,6 @@
                         <h2 class="component-header push-top mobile-flush-top text-white">
                             <%= assigns.series["title"] %>
                         </h2>
-                        <%# <span class="metadata soft-quarter-left"> %>
-                            <%# <%= assigns.series["startDate"] %>
-                            <%# <%= assigns.series["endDate"] %>
-                        <%# </span> %>
                     </div>
                     <div class="row quiet" style="color: #E7E7E7;">
                         <%= raw assigns.series["description"] %>
@@ -35,12 +31,14 @@
                             <img alt="<%= message["title"] %>" data-src="<%= get_message_still(message) %>" class="card-img-top imgix-fluid" />
                         </a>
                         <div class="card-block">
-                            <h4 class="card-title ellipsis">
-                                <%= message["title"] %>
-                            </h4>
-                            <p class="text-muted">
-                                <%= message["date"] %>
-                            </p>
+                            <a href="/message/<%= message["id"] %>/<%= linkify_title(message["title"]) %>/">
+                                <h4 class="card-title ellipsis">
+                                    <%= message["title"] %>
+                                </h4>
+                                <p class="text-muted">
+                                    <%= convert_date_string(message["date"]) %>
+                                </p>
+                            </a>
                         </div>
                     </div>
                   <% end %>

--- a/apps/crossroads_interface/web/views/cms_series_view.ex
+++ b/apps/crossroads_interface/web/views/cms_series_view.ex
@@ -24,4 +24,10 @@ defmodule CrossroadsInterface.CmsSeriesView do
   defp has_message_still?(message) do
     (get_in(message, ["messageVideo", "still", "filename"]) != nil)
   end
+
+  def convert_date_string(date) do
+    {:ok, parsed_date} = Timex.parse(date, "%Y-%m-%d", :strftime)
+    {:ok, formatted_date} = Timex.Format.DateTime.Formatters.Strftime.format(parsed_date, "%m.%d.%Y")
+    formatted_date
+  end
 end


### PR DESCRIPTION
This PR handles: 
1. Wrapping the text-block of the message card in an `a` tag just like the `img`
2. Changing the date format from 'YYYY/MM/DD" to "MM.DD.YYYY"