### PR TITLE
DE4867 Add Meta Tags to Server Rendered Media Page

### DIFF
--- a/apps/crossroads_interface/test/plugs/media_meta_plug_test.exs
+++ b/apps/crossroads_interface/test/plugs/media_meta_plug_test.exs
@@ -1,0 +1,25 @@
+defmodule CrossroadsInterface.Plugs.MediaMetaTest do
+  use CrossroadsInterface.ConnCase
+  alias CrossroadsContent.CmsClient
+  import Mock
+
+  @series_object %{"description" => "Wizard Cow is a hilariously renamed animal as per the internet", 
+                   "image" => %{"filename" => "my_file.jpg"},
+                   "title" => "Wizard Cow",
+                   "className" => "series",
+                   "id" => "222"}
+
+  test "Sets meta data when request to get a server rendered media page occurs", %{conn: conn} do
+    with_mock CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end] do
+      app_env = Application.get_env(:crossroads_interface, :cookie_domain)
+      conn = CrossroadsInterface.Plug.MediaMeta.call(conn, @series_object)
+  
+      assert conn.assigns.meta_title == "Wizard Cow | Crossroads"
+      assert conn.assigns.meta_description == "Wizard Cow is a hilariously renamed animal as per the internet"
+      assert conn.assigns.meta_url == "https://#{if app_env != "", do: app_env, else: "www"}.crossroads.net/series/222/wizard-cow"
+      assert conn.assigns.meta_type == "website"
+      assert conn.assigns.meta_image == "my_file.jpg"
+    end
+  end       
+end
+  

--- a/apps/crossroads_interface/test/plugs/media_meta_plug_test.exs
+++ b/apps/crossroads_interface/test/plugs/media_meta_plug_test.exs
@@ -4,12 +4,17 @@ defmodule CrossroadsInterface.Plugs.MediaMetaTest do
   import Mock
 
   @series_object %{"description" => "Wizard Cow is a hilariously renamed animal as per the internet", 
-                   "image" => %{"filename" => "my_file.jpg"},
-                   "title" => "Wizard Cow",
-                   "className" => "series",
-                   "id" => "222"}
+    "image" => %{"filename" => "my_file.jpg"},
+    "title" => "Wizard Cow",
+    "className" => "series",
+    "id" => "222"}
 
-  test "Sets meta data when request to get a server rendered media page occurs", %{conn: conn} do
+  @series_object_sans_image %{"description" => "Wizard Cow is a hilariously renamed animal as per the internet",
+    "title" => "Wizard Cow",
+    "className" => "series",
+    "id" => "222"}
+
+  test "Sets specific meta data when request to get a server rendered media page occurs", %{conn: conn} do
     with_mock CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end] do
       app_env = Application.get_env(:crossroads_interface, :cookie_domain)
       conn = CrossroadsInterface.Plug.MediaMeta.call(conn, @series_object)
@@ -20,6 +25,19 @@ defmodule CrossroadsInterface.Plugs.MediaMetaTest do
       assert conn.assigns.meta_type == "website"
       assert conn.assigns.meta_image == "my_file.jpg"
     end
-  end       
+  end
+
+  test "Sets default meta image when no image is present", %{conn: conn} do
+    with_mock CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end] do
+      app_env = Application.get_env(:crossroads_interface, :cookie_domain)
+      conn = CrossroadsInterface.Plug.MediaMeta.call(conn, @series_object_sans_image)
+  
+      assert conn.assigns.meta_title == "Wizard Cow | Crossroads"
+      assert conn.assigns.meta_description == "Wizard Cow is a hilariously renamed animal as per the internet"
+      assert conn.assigns.meta_url == "https://#{if app_env != "", do: app_env, else: "www"}.crossroads.net/series/222/wizard-cow"
+      assert conn.assigns.meta_type == "website"
+      assert conn.assigns.meta_image == "http://crds-cms-uploads.imgix.net/content/images/cr-social-sharing-still-bg.jpg"
+    end
+  end
 end
   

--- a/apps/crossroads_interface/web/controllers/cms_series_controller.ex
+++ b/apps/crossroads_interface/web/controllers/cms_series_controller.ex
@@ -18,8 +18,9 @@ defmodule CrossroadsInterface.CmsSeriesController do
 
     case series do
       {:ok, _response_code, %{"series" => series}} ->
-        render conn, "individual_series.html", %{series: series,
-          css_files: [ "/css/app.css", "/js/legacy/legacy.css" ]}
+        Plug.MediaMeta.call(conn, series)
+        |> render("individual_series.html", %{series: series,
+          css_files: [ "/css/app.css", "/js/legacy/legacy.css" ]})
       {:error, _response_code, response_data} ->
         Logger.error("Error getting series data from CMS | Response: #{response_data["message"]}")
         NotfoundController.notfound(conn, %{})

--- a/apps/crossroads_interface/web/plugs/media_meta_plug.ex
+++ b/apps/crossroads_interface/web/plugs/media_meta_plug.ex
@@ -1,0 +1,64 @@
+defmodule CrossroadsInterface.Plug.MediaMeta do
+  @moduledoc """
+  Get all required and optional META tag properties from the CMS
+  and supply them to the template.
+  """
+  alias CrossroadsContent.CmsClient
+  import Plug.Conn
+
+  @default_image "http://crds-cms-uploads.imgix.net/content/images/cr-social-sharing-still-bg.jpg"
+  @max_description_len 305
+
+  def init(default), do: default
+
+  def call(conn, media_object) do    
+    site_config = 1
+    |> CmsClient.get_site_config
+    |> match_site_config
+
+    conn
+    |> assign(:meta_description, get_description(media_object))
+    |> assign(:meta_title, get_title(media_object))
+    |> assign(:meta_url, create_url(media_object))
+    |> assign(:meta_type, "website")
+    |> assign(:meta_image, get_image_file(media_object))
+    |> assign(:meta_siteconfig_title, "Crossroads")
+    |> assign(:meta_siteconfig_locale, Map.get(site_config, "locale", "en_US"))
+    |> assign(:meta_siteconfig_facebook, Map.get(site_config, "facebook", ""))
+    |> assign(:meta_siteconfig_twitter, Map.get(site_config, "twitter", ""))
+  end
+
+  defp get_description media do
+    description = if media["description"], do: media["description"], else: ""
+    {:safe, content} = PhoenixHtmlSanitizer.Helpers.strip_tags(description)
+    content |> String.slice(0, @max_description_len - 1)
+  end
+
+  defp get_title media do
+    title = if media["title"], do: media["title"], else: "Crossroads"
+    "#{title} | Crossroads"
+  end
+
+  defp get_image_file media do
+    if media["image"]["filename"], do: media["image"]["filename"], else: @default_image
+  end
+
+  defp create_url media do
+    app_env = Application.get_env(:crossroads_interface, :cookie_domain)
+    url_prefix =  if app_env != "", do: app_env, else: "www"
+    resource = String.downcase(media["className"])
+
+    "https://#{url_prefix}.crossroads.net/#{resource}/#{media["id"]}/#{linkify_title(media["title"])}"
+  end
+
+  defp linkify_title title do
+    String.downcase(title)
+    |> String.replace(" ", "-")
+  end
+
+  defp match_site_config({:ok, _resp_code, body}) do
+    body
+    |> Map.get("siteConfig", %{})
+  end
+  defp match_site_config(_), do: %{}
+end


### PR DESCRIPTION
The changes made to make /series/:id/individual-series a server rendered
page ended up breaking the functionality that would add meta data to the
page. These changes add the logic necessary to get the meta data back
into the rendered HTML