### PR TITLE
DE4906: Fix 500 error on series with no messages

### DIFF
--- a/apps/crossroads_interface/test/views/cms_series_view_test.exs
+++ b/apps/crossroads_interface/test/views/cms_series_view_test.exs
@@ -2,6 +2,9 @@ defmodule CrossroadsInterface.CmsSeriesViewTest do
   use CrossroadsInterface.ConnCase
   alias CrossroadsInterface.CmsSeriesView
 
+  @series_good_data [%{"message1" => "foo"}, %{"message2" => "bar"}]
+  @series_bad_data_1 nil
+  @series_bad_data_2 []
   @truthy_message %{"date" => "2017-11-25", "id" => 3883,
     "messageVideo" => %{
       "source" => %{"my_key" => "my_value"},
@@ -32,6 +35,27 @@ defmodule CrossroadsInterface.CmsSeriesViewTest do
       }
     },
     "title" => "Say No To Good Things for the Sake of Great Things"}
+
+  test "has_messages?/1 returns true when map has messages" do
+    actual = CmsSeriesView.has_messages?(@series_good_data)
+    expected = true
+
+    assert actual == expected
+  end
+
+  test "has_messages?/1 returns false when map does not have messages" do
+    actual = CmsSeriesView.has_messages?(@series_bad_data_1)
+    expected = false
+
+    assert actual == expected
+  end
+
+  test "has_messages?/1 returns false when map has an empty list for the values of messages" do
+    actual = CmsSeriesView.has_messages?(@series_bad_data_2)
+    expected = false
+
+    assert actual == expected
+  end
 
   test "message_valid?(message) returns true when all attributes are present" do
     actual = CmsSeriesView.message_valid?(@truthy_message)

--- a/apps/crossroads_interface/web/templates/cms_series/individual_series.html.eex
+++ b/apps/crossroads_interface/web/templates/cms_series/individual_series.html.eex
@@ -24,6 +24,7 @@
     <div class="row">
         <div class="card-deck">
             <div class="card-deck--expanded-layout card-deck--wrap" style="padding-left: .5rem; padding-right: .5rem;">
+              <%= if has_messages?(assigns.series["messages"]) do %>
                 <%= for message <- Enum.reverse(assigns.series["messages"]) do %>
                   <%= if message_valid?(message) do %>
                     <div class="card card--thumbnail">
@@ -43,6 +44,7 @@
                     </div>
                   <% end %>
                 <% end %>
+              <% end %>
             </div>
         </div>
     </div>

--- a/apps/crossroads_interface/web/views/cms_series_view.ex
+++ b/apps/crossroads_interface/web/views/cms_series_view.ex
@@ -1,6 +1,10 @@
 defmodule CrossroadsInterface.CmsSeriesView do
   use CrossroadsInterface.Web, :view
 
+  def has_messages?(article_messages) do
+    article_messages != nil && article_messages != []
+  end
+
   def message_valid?(message) do
     has_title?(message) && has_message_video?(message) && has_message_still?(message)
   end


### PR DESCRIPTION
Previously, when a series was created and didn't have any messages, trying to access the series page would cause a 500. This fixes that issue.