### PR TITLE
US11996: base article styles

### DIFF
--- a/apps/crossroads_interface/web/static/css/main.scss
+++ b/apps/crossroads_interface/web/static/css/main.scss
@@ -44,6 +44,7 @@
   @import './pages/homepage';
   @import './pages/locations';
   @import './pages/media';
+  @import './pages/article';
 }
 
 .noscroll {

--- a/apps/crossroads_interface/web/static/css/pages/_article.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_article.scss
@@ -1,0 +1,119 @@
+.article {
+
+    .article_para {
+        font-size: 17px;
+        line-height: 1.55;
+    }
+
+    .article_blockquote {
+        padding: 24px;
+        border-left: 4px solid $cr-cyan;
+        border-top: 0;
+        border-right: 0;
+        border-bottom: 0;
+        font-size: 32px;
+    }
+
+   .article_author {
+       color: $cr-cyan;
+       font-size: 16px;
+   }
+
+    .article_body {
+        margin: 3rem 0;
+
+        p {
+            margin-bottom: 1.5rem;
+        }
+    }
+
+    .article_inlineImg,
+    .article_fullImg {
+        margin-bottom: 1rem;
+    }
+
+    .article_sidebar {
+        position: sticky;
+        top: 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .article_shareBtn {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 3rem;
+        height: 3rem;
+        color: white;
+        background-color: $cr-cyan;
+        border: 0;
+
+        &:hover {
+            cursor: pointer;
+            opacity: .8;
+        }
+
+        &.article_shareBtn--facebook {
+            background-color: #3b5998;
+        }
+
+        &.article_shareBtn--twitter {
+            background-color: #1da1f2;
+        }
+
+        &.article_shareBtn--email {
+            background-color: $cr-teal;
+        }
+
+        &.article_shareBtn--text {
+            background-color: $cr-gold;
+        }
+
+        .icon {
+            width: 20px;
+        }
+    }
+
+    .article_authorBlock {
+        display: flex;
+        align-items: center;
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid rgba(0,0,0,.2);
+
+        .article_authorAvatar {
+            margin-right: 1rem;
+        }
+
+        p {
+            margin: 0;
+        }
+    }
+}
+
+.card--media {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    margin-bottom: 0;
+
+    .card-img-top {
+        width: 4rem;
+        min-width: 4rem;
+        height: 4rem;
+    }
+
+    .card-block {
+        padding: 0;
+        margin-left: 1rem;
+
+        .list-header {
+            margin-bottom: 0;
+        }
+
+        .tagline {
+            margin-top: 4px;
+        }
+    }
+}


### PR DESCRIPTION
An attempt was made to use crds-styles when possible. This PR sets up basic css setup for:
  - an article
  - article header
  - a 100% width hero image
  - big and inline images
  - a new type of small media card for the sidebar
  - share buttons
  - author block