### PR TITLE
US10234 - Countdown Clock on Live

### DIFF
--- a/apps/crossroads_interface/package-lock.json
+++ b/apps/crossroads_interface/package-lock.json
@@ -2396,7 +2396,7 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crds-styles": {
-      "version": "github:crdschurch/crds-styles#23e3ab04dfb220356bac4cf5fef9b54efb2db5d3",
+      "version": "github:crdschurch/crds-styles#e805ad0ac5d8af91ab632599d0ed4d1a04de45e9",
       "requires": {
         "autoprefixer": "7.2.5",
         "bootstrap-sass": "3.3.7",

--- a/apps/crossroads_interface/web/static/css/pages/_live.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_live.scss
@@ -1,11 +1,13 @@
 .btn-live-schedule-trigger {
   color: $cr-white;
   display: flex;
-  float: right;
-  margin: 0;
+  margin: -1.375rem 0 0;
   padding-left: .75rem;
   padding-right: .75rem;
+  position: absolute;
+  right: 0;
   text-transform: uppercase;
+  top: 50%;
 
   > * {
     margin: 0 .25rem;

--- a/apps/crossroads_interface/web/static/js/home_page/countdown.js
+++ b/apps/crossroads_interface/web/static/js/home_page/countdown.js
@@ -234,7 +234,7 @@ CRDS.Countdown = class Countdown {
   }
 
   // Convert Single Digit to Double Digit
-  // check if value is < 10 
+  // check if value is < 10
   // if yes, then add a 0 onto the front
   // if no, then nothing
   static padZero(number) {


### PR DESCRIPTION
Position the see schedule absolutely so the clock can be centered.

The markup I've used for the countdown content block is:

```html
<div class="container-fluid bg-info sticky-top">
  <div class="row">
    <a href="javascript:void(0)" class="btn btn-live-schedule-trigger hidden-xs" data-smooth-scroll-to="live-stream-schedule" data-smooth-scroll-offset="92">
      <span>See Schedule</span>
      <svg class="icon icon-1" viewBox="0 0 256 256">
        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-down"></use>
      </svg>
    </a>
    <div class="crds-countdown countdown time">
      <span data-stream-live="show">
        <span class="countdown-header push-right">Live stream in progress...</span>
        <a class="btn countdown-btn" href="/live/stream">Watch Now</a>
      </span>
      <span data-stream-live="hide">
        <span class="countdown-header">Join the live stream in...</span>
        <ul class="countdown-timer list-inline">
          <li class="countdown-days days">03</li>
          <li class="countdown-hours hours">00</li>
          <li class="countdown-minutes minutes">42</li>
          <li class="countdown-seconds seconds">37</li>
        </ul>
      </span>
    </div>
  </div>
</div>
```

It should just work because the countdown script is already being instantiated for the jumbotron switching.

And to test the live portion of this, you can simply add/remove `hide` classes from the necessary elements.