### PR TITLE
US12169 - Create Live Stream CMS Page

### DIFF
--- a/apps/crossroads_interface/web/static/css/main.scss
+++ b/apps/crossroads_interface/web/static/css/main.scss
@@ -65,11 +65,6 @@
   left: 0;
 }
 
-body.dark-theme {
-  background-color: rgba(0,0,0,1); // #000000
-  color: rgba(115,115,115,1); // #737373
-
-  hr {
-    border-top-color: darken(rgba(77,77,77,1), 15);
-  }
-}
+// Load dark-theme styles outside the crds-styles context.
+@import 'node_modules/crds-styles/assets/stylesheets/variables';
+@import 'node_modules/crds-styles/assets/stylesheets/themes/dark';

--- a/apps/crossroads_interface/web/static/css/main.scss
+++ b/apps/crossroads_interface/web/static/css/main.scss
@@ -64,3 +64,12 @@
   bottom: 0;
   left: 0;
 }
+
+body.dark-theme {
+  background-color: rgba(0,0,0,1); // #000000
+  color: rgba(115,115,115,1); // #737373
+
+  hr {
+    border-top-color: darken(rgba(77,77,77,1), 15);
+  }
+}

--- a/apps/crossroads_interface/web/static/css/pages/_live.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_live.scss
@@ -1,3 +1,6 @@
+/*
+ * Live
+ */
 .btn-live-schedule-trigger {
   color: $cr-white;
   display: flex;
@@ -19,5 +22,37 @@
   &.active {
     color: $cr-white;
     text-decoration: none;
+  }
+}
+
+
+
+
+/*
+ * Live Stream
+ */
+.crds-shared-header .header--live-stream {
+  li {
+    padding: .625rem 0;
+
+    > a:not(.cta) {
+      color: $cr-white;
+      padding: 0;
+    }
+
+    a:not(.cta):hover {
+      background-color: transparent;
+      color: $cr-gray-light;
+    }
+
+    .link-icon-text {
+      vertical-align: middle;
+    }
+  }
+
+  ul.nav-pills > li > a > svg {
+    display: inline-block;
+    margin: 0 .25rem 0 0;
+    vertical-align: middle;
   }
 }


### PR DESCRIPTION
Adds support for dark theme pages in Maestro. It also overrides some shared header styles to support the header on the live stream page.