### PR TITLE
Defect/de5021 stretched images

### DIFF
--- a/apps/crossroads_interface/package-lock.json
+++ b/apps/crossroads_interface/package-lock.json
@@ -2396,9 +2396,7 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crds-styles": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/crds-styles/-/crds-styles-2.2.0.tgz",
-      "integrity": "sha512-PtzvBO4gc/+oE4ANdZWqc8T5QiGbtyC4n3M/oUrei5TTevGGAP2HLOGXbp9e4Y3BNsgTxulhLgKuY/0kvKIlCQ==",
+      "version": "github:crdschurch/crds-styles#0254cdb89d78e60352801eaa759575986ac1cb87",
       "requires": {
         "autoprefixer": "7.2.5",
         "bootstrap-sass": "3.3.7",

--- a/apps/crossroads_interface/web/static/css/pages/_live.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_live.scss
@@ -25,6 +25,28 @@
   }
 }
 
+.page--live & {
+  .card-deck {
+    .card-img-top {
+      object-fit: cover;
+      width: 100%;
+      max-height: 151px;
+
+      @media screen and (min-width: $screen-sm + 1) {
+        max-height: 95px;
+      }
+
+      @media screen and (min-width: $screen-md + 1) {
+        max-height: 124px;
+      }
+
+      @media screen and (min-width: $screen-lg) {
+        max-height: 152px;
+      }
+    }
+  }
+}
+
 
 
 
@@ -32,6 +54,7 @@
  * Live Stream
  */
 .page--live-stream & {
+  * { border: 5px solid lime;}
   .crds-shared-header .header {
     ul.nav-pills > li:not(.open) {
       padding: .625rem 0;

--- a/apps/crossroads_interface/web/static/css/pages/_live.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_live.scss
@@ -54,7 +54,6 @@
  * Live Stream
  */
 .page--live-stream & {
-  * { border: 5px solid lime;}
   .crds-shared-header .header {
     ul.nav-pills > li:not(.open) {
       padding: .625rem 0;


### PR DESCRIPTION
Add sizing parameters and object-fit rule to contain images without distorting them. This might be a temporary solution until cards can be refactored to support background-images (as Brian requested).

No corresponding PRs.