### PR TITLE
US12172 - Add Streamspot Player to Live Stream

### DIFF
--- a/apps/crossroads_interface/web/static/css/pages/_live.scss
+++ b/apps/crossroads_interface/web/static/css/pages/_live.scss
@@ -58,6 +58,9 @@
         vertical-align: middle;
       }
     }
+  }
 
+  [data-streamspot-player] {
+    width: 100%;
   }
 }

--- a/apps/crossroads_interface/web/static/js/app.js
+++ b/apps/crossroads_interface/web/static/js/app.js
@@ -9,6 +9,7 @@ import DataTracker from './dataTracker';
 import UserService from './userService';
 import imgixImagesLoaded from './imgixImagesLoaded';
 import * as SmoothScroller from './web_components/smooth_scroller';
+import HeightWatcher from './web_components/height_watcher';
 
 const domReady = (callback) => {
   document.addEventListener('DOMContentLoaded', callback);

--- a/apps/crossroads_interface/web/static/js/home_page/countdown.js
+++ b/apps/crossroads_interface/web/static/js/home_page/countdown.js
@@ -159,8 +159,11 @@ CRDS.Countdown = class Countdown {
     const currentEndDate = this.currentEvent.end;
     const secondsUntilStreamEnd = (Countdown.convertDate(currentEndDate, this.TIMEZONE_OFFSET) - (new Date())) / 1000;
 
-    let streamspotPlayerUrl = `https://player2.streamspot.com/?playerId=1adb55de`;
-    $('[data-streamspot-player]').attr('src', streamspotPlayerUrl);
+    $('[data-streamspot-player]').each(function(idx) {
+      let playerId = $(this).data('streamspot-player')
+      let streamspotPlayerUrl = `https://player2.streamspot.com/?playerId=${playerId}`;
+      $(this).attr('src', streamspotPlayerUrl);
+    });
 
     this.timeoutId = setTimeout(() => {
       if (this.nextEvent == null) {

--- a/apps/crossroads_interface/web/static/js/home_page/countdown.js
+++ b/apps/crossroads_interface/web/static/js/home_page/countdown.js
@@ -159,6 +159,9 @@ CRDS.Countdown = class Countdown {
     const currentEndDate = this.currentEvent.end;
     const secondsUntilStreamEnd = (Countdown.convertDate(currentEndDate, this.TIMEZONE_OFFSET) - (new Date())) / 1000;
 
+    let streamspotPlayerUrl = `https://player2.streamspot.com/?playerId=1adb55de`;
+    $('[data-streamspot-player]').attr('src', streamspotPlayerUrl);
+
     this.timeoutId = setTimeout(() => {
       if (this.nextEvent == null) {
         this.getStreamspotStatus();

--- a/apps/crossroads_interface/web/static/js/web_components/height_watcher.js
+++ b/apps/crossroads_interface/web/static/js/web_components/height_watcher.js
@@ -1,0 +1,26 @@
+window.CRDS = window.CRDS || {};
+
+CRDS.HeightWatcher = class HeightWatcher {
+
+  constructor(el) {
+    this.el = $(el);
+    this.ratio = parseFloat(this.el.data('watch-height-ratio'));
+
+    this.bindEvents();
+    this.resize();
+  }
+
+  bindEvents() {
+    $(window).resize(() => this.resize());
+  }
+
+  resize() {
+    this.el.outerHeight(this.el.outerWidth() * this.ratio);
+  }
+}
+
+$(document).ready(function() {
+  $('[data-watch-height-ratio]').each(function(idx) {
+    new CRDS.HeightWatcher(this);
+  });
+});


### PR DESCRIPTION
- Adds video player support to the countdown script (I don't love this code being here, but it was the quickest way to get it implemented)
- Add style for streamspot iframe on /live/stream
- Add a height ratio resizer script that will adjust height based on width for any given ratio