### PR TITLE
Update code to remove warning messages in compilation output

### DIFF
--- a/apps/crossroads_interface/test/controllers/cms_page_controller_test.exs
+++ b/apps/crossroads_interface/test/controllers/cms_page_controller_test.exs
@@ -41,69 +41,69 @@ defmodule CrossroadsInterface.CmsPageControllerTest do
         "legacyStyles" => "0",
         "canEditType" => nil}}
 
-  def with_session(conn) do
+  def with_session(_conn) do
     session_opts = Plug.Session.init(store: :cookie, key: "_app",
                                       encryption_salt: "abc", signing_salt: "abc")
-    conn()
+    build_conn()
     |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
     |> Plug.Session.call(session_opts)
     |> Plug.Conn.fetch_session()
     |> Plug.Conn.fetch_query_params()
   end
 
-  test "Getting a page that exists at /habitat/", %{conn: conn} do
+  test "Getting a page that exists at /habitat/", %{conn: _conn} do
     with_mocks([ {CmsClient, [], [get_system_page: fn(page) -> {:ok, 200, fake_system_page(page)} end]},
                  {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
                  {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
                  {Pages, [], [get_page: fn(_path) -> @get_page_response end ]},
                  {Pages, [], [get_page: fn(_path, _stage) -> @get_page_response end ]}]) do
-      conn = get conn, "/habitat/"
+      conn = get build_conn(), "/habitat/"
       assert html_response(conn, 200)
       assert called Pages.get_page("/habitat/", false)
     end
   end
 
-  test "Getting a staged page that exists at /habitat/", %{conn: conn} do
+  test "Getting a staged page that exists at /habitat/", %{conn: _conn} do
     with_mocks([ {CmsClient, [], [get_system_page: fn(page) -> {:ok, 200, fake_system_page(page)} end]},
                  {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
                  {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
                  {Pages, [], [get_page: fn(_path) -> @get_page_response end ]},
                  {Pages, [], [get_page: fn(_path, _stage) -> @get_page_response end ]}]) do
-      conn = get conn, "/habitat/", %{"stage" => "Stage"}
+      conn = get build_conn(), "/habitat/", %{"stage" => "Stage"}
       assert html_response(conn, 200)
       assert called Pages.get_page("/habitat/", true)
     end
   end
 
-  test "Get should get layout from page", %{conn: conn} do
+  test "Get should get layout from page", %{conn: _conn} do
     with_mocks([ {CmsClient, [], [get_system_page: fn(page) -> {:ok, 200, fake_system_page(page)} end]},
                  {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
                  {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
                  {Pages, [], [get_page: fn(_path) -> @get_page_response end ]},
                  {Pages, [], [get_page: fn(_path, _) -> @get_page_response end ]}]) do
-      conn = get conn, "/habitat/"
+      conn = get build_conn(), "/habitat/"
       assert conn.assigns[:layout] == {CrossroadsInterface.LayoutView, "centered_content_page.html"}
     end
   end
 
-  test "Get should get crds styles from page", %{conn: conn} do
+  test "Get should get crds styles from page", %{conn: _conn} do
       with_mocks([ {CmsClient, [], [get_system_page: fn(page) -> {:ok, 200, fake_system_page(page)} end]},
                  {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
                  {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
                  {Pages, [], [get_page: fn(_path) -> @get_page_response end ]},
                  {Pages, [], [get_page: fn(_path, _) -> @get_page_response end ]}]) do
-      conn = get conn, "/habitat/"
+      conn = get build_conn(), "/habitat/"
       assert conn.assigns[:crds_styles] == "crds-legacy-styles"
     end
   end
 
-  test "Get should get body styles from page", %{conn: conn} do
+  test "Get should get body styles from page", %{conn: _conn} do
     with_mocks([ {CmsClient, [], [get_system_page: fn(page) -> {:ok, 200, fake_system_page(page)} end]},
                  {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
                  {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
                  {Pages, [], [get_page: fn(_path) -> @get_page_response end ]},
                  {Pages, [], [get_page: fn(_path, _) -> @get_page_response end ]}]) do
-      conn = get conn, "/habitat/"
+      conn = get build_conn(), "/habitat/"
       assert conn.assigns[:body_class] == "dad-bod goofy"
     end
   end
@@ -116,7 +116,7 @@ defmodule CrossroadsInterface.CmsPageControllerTest do
                  {Pages, [], [get_page: fn(_path, _) -> @get_auth_page_response end ]},
                  {CrossroadsInterface.Plug.Authorized, [], [call: fn(conn, _) -> assign(conn, :authorized, false) end]}
               ]) do
-      conn = get conn, "/form/"
+      conn = get build_conn(), "/form/"
       assert html_response(conn, 302)
     end
   end
@@ -130,7 +130,7 @@ defmodule CrossroadsInterface.CmsPageControllerTest do
        {Pages, [], [get_page: fn(_path, _) -> @get_auth_page_response end ]},
        {CrossroadsInterface.Plug.Authorized, [], [call: fn(conn, _) -> assign(conn, :authorized, true) end]}
      ]) do
-      conn = get conn, "/form/"
+      conn = get build_conn(), "/form/"
       assert conn.resp_cookies["redirectUrl"].value == "/form/"
       assert conn.resp_cookies["params"].value == ""
     end
@@ -146,10 +146,10 @@ defmodule CrossroadsInterface.CmsPageControllerTest do
       {CrossroadsInterface.Plug.Authorized, [], [call: fn(conn, _) -> assign(conn, :authorized, true) end]}
     ]) do
       conn =
-        conn
+        build_conn()
         |> with_session
         |> Map.put(:req_cookies, %{"intsessionId" => "1234"})
-        |> get "/form/"
+        |> get("/form/")
       assert html_response(conn, 200)
     end
   end

--- a/apps/crossroads_interface/test/controllers/cms_series_controller_test.exs
+++ b/apps/crossroads_interface/test/controllers/cms_series_controller_test.exs
@@ -1,6 +1,4 @@
 defmodule CrossroadsInterface.CmsSeriesControllerTest do
-  alias CrossroadsContent.CmsClient
-  alias CrossroadsContent.Pages
   use CrossroadsInterface.ConnCase
   import Mock
   
@@ -41,24 +39,24 @@ defmodule CrossroadsInterface.CmsSeriesControllerTest do
                                               "uRL" => "/register"}]}
 
   test "getting an individual series", %{conn: conn} do
-    with_mocks([ {CmsClient, [], [get_system_page: fn(_page) -> {:ok, 200, @system_page_response} end]},
-                 {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, %{}} end]},
-                 {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
-                 {CmsClient, [], [get_series_by_id: fn(_id) -> @get_series_200_response end]}]) do
+    with_mocks([ {CrossroadsContent.CmsClient, [], [get_system_page: fn(_page) -> {:ok, 200, @system_page_response} end]},
+                 {CrossroadsContent.CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, %{}} end]},
+                 {CrossroadsContent.CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
+                 {CrossroadsContent.CmsClient, [], [get_series_by_id: fn(_id) -> @get_series_200_response end]}]) do
       conn = get conn, "/series/584"
-      assert called CmsClient.get_series_by_id("584")
+      assert called CrossroadsContent.CmsClient.get_series_by_id("584")
       assert html_response(conn, 200)
     end
   end
 
   test "handling when getting series results in a 404", %{conn: conn} do
-    with_mocks([ {CmsClient, [], [get_system_page: fn(_page) -> {:ok, 200, @system_page_response} end]},
-                 {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, %{}} end]},
-                 {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
-                 {CmsClient, [], [get_series_by_id: fn(_id) -> @get_series_404_response end]},
-                 {CmsClient, [], [get_page: fn("/servererror/", false) -> {:ok, 200, fake_error_page()} end]}]) do
+    with_mocks([ {CrossroadsContent.CmsClient, [], [get_system_page: fn(_page) -> {:ok, 200, @system_page_response} end]},
+                 {CrossroadsContent.CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, %{}} end]},
+                 {CrossroadsContent.CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]},
+                 {CrossroadsContent.CmsClient, [], [get_series_by_id: fn(_id) -> @get_series_404_response end]},
+                 {CrossroadsContent.CmsClient, [], [get_page: fn("/servererror/", false) -> {:ok, 200, fake_error_page()} end]}]) do
       conn = get conn, "/series/897547895"
-      assert called CmsClient.get_series_by_id("897547895")
+      assert called CrossroadsContent.CmsClient.get_series_by_id("897547895")
       assert html_response(conn, 404)
     end
   end

--- a/apps/crossroads_interface/test/controllers/crds_connect_controller_test.exs
+++ b/apps/crossroads_interface/test/controllers/crds_connect_controller_test.exs
@@ -1,7 +1,5 @@
 defmodule CrossroadsInterface.CrdsConnectControllerTest do
   use CrossroadsInterface.ConnCase
-  alias CrossroadsContent.CmsClient
-  alias CrossroadsContent.Pages
   import Mock
 
   @content_block_call %{"contentBlocks" => [%{"id" => 1, "title" => "generalError"}]}
@@ -20,18 +18,18 @@ defmodule CrossroadsInterface.CrdsConnectControllerTest do
                                               "uRL" => "/register"}]}
 
   test "GET /connect should return 200 status", %{conn: conn} do
-    with_mocks([ {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, @content_block_call} end]},
-                 {CmsClient, [], [get_system_page: fn("connect") -> {:ok, 200, @system_page_response} end]},
-                 {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
+    with_mocks([ {CrossroadsContent.CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, @content_block_call} end]},
+                 {CrossroadsContent.CmsClient, [], [get_system_page: fn("connect") -> {:ok, 200, @system_page_response} end]},
+                 {CrossroadsContent.CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
       conn = get conn, "/connect"
       assert html_response(conn, 200)
     end
   end
 
   test "GET /connect should set redirectUrl cookie", %{conn: conn} do
-    with_mocks([ {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, @content_block_call} end]},
-                 {CmsClient, [], [get_system_page: fn("connect") -> {:ok, 200, @system_page_response} end]},
-                 {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
+    with_mocks([ {CrossroadsContent.CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, @content_block_call} end]},
+                 {CrossroadsContent.CmsClient, [], [get_system_page: fn("connect") -> {:ok, 200, @system_page_response} end]},
+                 {CrossroadsContent.CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
       Application.put_env(:crossroads_interface, :cookie_domain, ".crossroads.net")
       conn = get conn, "/connect"
       assert conn.resp_cookies == %{"redirectUrl" => %{http_only: false, value: "/connect", domain: ".crossroads.net"}, "params" => %{domain: ".crossroads.net", http_only: false, value: ""}}

--- a/apps/crossroads_interface/test/controllers/crds_group_leader_controller_test.exs
+++ b/apps/crossroads_interface/test/controllers/crds_group_leader_controller_test.exs
@@ -1,23 +1,21 @@
 defmodule CrossroadsInterface.CrdsGroupLeaderControllerTest do
   use CrossroadsInterface.ConnCase
-  alias CrossroadsContent.CmsClient
-  alias CrossroadsContent.Pages
   import Mock
 
   describe "renders correctly" do
     test "GET /group-leader", %{conn: conn} do
-      with_mocks([ {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
-                   {CmsClient, [], [get_system_page: fn("group-leader") -> {:ok, 200, fake_system_page("group-leader")} end]},
-                   {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
+      with_mocks([ {CrossroadsContent.CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
+                   {CrossroadsContent.CmsClient, [], [get_system_page: fn("group-leader") -> {:ok, 200, fake_system_page("group-leader")} end]},
+                   {CrossroadsContent.CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
         conn = get conn, "/group-leader"
         assert html_response(conn, 200)
       end
     end
 
     test "GET /group-leader displays <app-root>", %{conn: conn} do
-      with_mocks([ {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
-                   {CmsClient, [], [get_system_page: fn("group-leader") -> {:ok, 200, fake_system_page("group-leader")} end]},
-                   {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
+      with_mocks([ {CrossroadsContent.CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
+                   {CrossroadsContent.CmsClient, [], [get_system_page: fn("group-leader") -> {:ok, 200, fake_system_page("group-leader")} end]},
+                   {CrossroadsContent.CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
         conn = get conn, "/group-leader"
         assert html_response(conn, 200) =~ "<app-root> Loading... </app-root>"
       end
@@ -25,18 +23,18 @@ defmodule CrossroadsInterface.CrdsGroupLeaderControllerTest do
   end
 
   test "GET /group-leader sets correct base_href", %{conn: conn} do
-    with_mocks([ {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
-                 {CmsClient, [], [get_system_page: fn("group-leader") -> {:ok, 200, fake_system_page("group-leader")} end]},
-                 {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
+    with_mocks([ {CrossroadsContent.CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
+                 {CrossroadsContent.CmsClient, [], [get_system_page: fn("group-leader") -> {:ok, 200, fake_system_page("group-leader")} end]},
+                 {CrossroadsContent.CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
       conn = get conn, "/group-leader"
       assert conn.assigns.base_href == "/group-leader"
     end
   end
 
   test "GET /group-leader sets correct layout", %{conn: conn} do
-    with_mocks([ {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
-                 {CmsClient, [], [get_system_page: fn("group-leader") -> {:ok, 200, fake_system_page("group-leader")} end]},
-                 {CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
+    with_mocks([ {CrossroadsContent.CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
+                 {CrossroadsContent.CmsClient, [], [get_system_page: fn("group-leader") -> {:ok, 200, fake_system_page("group-leader")} end]},
+                 {CrossroadsContent.CmsClient, [], [get_site_config: fn(1) -> {:ok, 200, %{}} end]} ]) do
       conn = get conn, "/group-leader"
       assert conn.assigns.layout == {CrossroadsInterface.LayoutView, "no_sidebar.html"}
     end

--- a/apps/crossroads_interface/test/controllers/legacy_controller_test.exs
+++ b/apps/crossroads_interface/test/controllers/legacy_controller_test.exs
@@ -70,7 +70,7 @@ defmodule CrossroadsInterface.LegacyControllerTest do
     end
   end
 
-  test "GET /non-existent is 404 when cookie unmatchedLegacyRoute=/non-existent/", %{conn: conn} do
+  test "GET /non-existent is 404 when cookie unmatchedLegacyRoute=/non-existent/", %{conn: _conn} do
     with_mocks([ {CmsClient, [], [get_content_blocks: fn() -> {:ok, 200, fake_content_blocks()} end]},
                  {CmsClient, [], [get_system_page: fn("non-existent") -> {:ok, 200, fake_system_page("")} end]},
                  {Pages,     [], [get_page: fn(_path, _stage) -> :error end]},

--- a/apps/crossroads_interface/test/plugs/authorized_plug_test.exs
+++ b/apps/crossroads_interface/test/plugs/authorized_plug_test.exs
@@ -5,7 +5,7 @@ defmodule CrossroadsInterface.AuthorizedPlugTest do
   import Mock
 
   test "should call the gateway with the cookie value", %{conn: conn} do
-    with_mock Authentication, [valid_token?: fn(token) -> true end] do
+    with_mock Authentication, [valid_token?: fn(_token) -> true end] do
       cookie_value = "@verySp#C!$lc)0k!e"
       conn
       |> put_req_cookie("intsessionId", cookie_value)
@@ -16,7 +16,7 @@ defmodule CrossroadsInterface.AuthorizedPlugTest do
   end
 
   test "should return true when a sessionId cookie is present and cookie is still valid", %{conn: conn} do
-    with_mock Authentication, [valid_token?: fn(token) -> true end] do
+    with_mock Authentication, [valid_token?: fn(_token) -> true end] do
       conn = conn
       |> put_req_cookie("intsessionId", "@verySp#C!$lc)0k!e")
       |> fetch_cookies()
@@ -26,7 +26,7 @@ defmodule CrossroadsInterface.AuthorizedPlugTest do
   end
 
   test "should return false when a sessionId cookie is present, but cookie is invalid", %{conn: conn} do
-    with_mock Authentication, [valid_token?: fn(token) -> false end] do
+    with_mock Authentication, [valid_token?: fn(_token) -> false end] do
       conn = conn
         |> put_req_cookie("intsessionId", "@verySp#C!$lc)0k!e")
         |> fetch_cookies()

--- a/apps/crossroads_interface/test/plugs/cms_page_plug_test.exs
+++ b/apps/crossroads_interface/test/plugs/cms_page_plug_test.exs
@@ -5,15 +5,15 @@ defmodule CrossroadsInterface.Plugs.CmsPageTest do
     require IEx
   
     test "given Pages.get_page returns :ok, assigns :page", %{conn: _conn} do
-      with_mock Pages, [get_page: fn(path, stage) -> {:ok, %{"content" => "<h1>Logged in page</h1>"}} end] do
+      with_mock Pages, [get_page: fn(_path, _stage) -> {:ok, %{"content" => "<h1>Logged in page</h1>"}} end] do
         conn = build_conn() 
         |> CrossroadsInterface.Plug.CmsPage.call(%{})
         assert conn.assigns[:page] == %{"content" => "<h1>Logged in page</h1>"}
       end
     end
   
-    test "given Pages.get_page returns anything other than :ok, does not assign :page", %{conn: conn} do
-      with_mock Pages, [get_page: fn(path, stage) -> {:error, ""} end] do
+    test "given Pages.get_page returns anything other than :ok, does not assign :page", %{conn: _conn} do
+      with_mock Pages, [get_page: fn(_path, _stage) -> {:error, ""} end] do
         conn = build_conn() 
         |> CrossroadsInterface.Plug.CmsPage.call(%{})
         assert conn.assigns[:page] == nil

--- a/apps/crossroads_interface/test/plugs/meta_plug_test.exs
+++ b/apps/crossroads_interface/test/plugs/meta_plug_test.exs
@@ -1,7 +1,6 @@
 defmodule CrossroadsInterface.Plugs.MetaTest do
   use CrossroadsInterface.ConnCase
   alias CrossroadsContent.CmsClient
-  alias CrossroadsContent.Pages
   import Mock
 
   @page_response  %{"submitButtonText" => nil, "title" => "Wizard Cow",

--- a/apps/crossroads_interface/test/views/cms_series_view_test.exs
+++ b/apps/crossroads_interface/test/views/cms_series_view_test.exs
@@ -25,8 +25,6 @@ defmodule CrossroadsInterface.CmsSeriesViewTest do
     }
   }
 
-  @message_video_missing %{"date" => "2017-11-25", "id" => 3883}
-
   @still_missing %{"date" => "2017-11-25", "id" => 3883,
     "messageVideo" => %{
       "source" => %{"my_key" => "my_value"},

--- a/apps/crossroads_interface/test/views/error_view_test.exs
+++ b/apps/crossroads_interface/test/views/error_view_test.exs
@@ -7,7 +7,7 @@ defmodule CrossroadsInterface.ErrorViewTest do
   import Phoenix.View
 
   test "renders 404_page.html" do
-    with_mock CmsClient, [get_page: fn("/servererror/", false) -> {:ok, 200, fake_error_page} end] do
+    with_mock CmsClient, [get_page: fn("/servererror/", false) -> {:ok, 200, fake_error_page()} end] do
       assert render_to_string(CrossroadsInterface.ErrorView, "404.html", []) =~ "We're sorry. There seems to have been an issue."
     end
   end
@@ -17,7 +17,7 @@ defmodule CrossroadsInterface.ErrorViewTest do
   end
 
   test "render any other should default to 404" do
-    with_mock CmsClient, [get_page: fn("/servererror/", false) -> {:ok, 200, fake_error_page} end] do
+    with_mock CmsClient, [get_page: fn("/servererror/", false) -> {:ok, 200, fake_error_page()} end] do
       assert render_to_string(CrossroadsInterface.ErrorView, "505.html", []) =~
            "We're sorry. There seems to have been an issue."  end
   end

--- a/apps/crossroads_interface/web/controllers/cms_series_controller.ex
+++ b/apps/crossroads_interface/web/controllers/cms_series_controller.ex
@@ -10,9 +10,6 @@ defmodule CrossroadsInterface.CmsSeriesController do
   plug Plug.BodyClass, "crds-styles"
   plug :put_layout, "screen_width.html"
 
-  @base_url Application.get_env(:crossroads_content, :cms_server_endpoint)
-  @timeout Application.get_env(:crossroads_content, :cms_timeout)
-
   def show(conn, %{"id" => id}) do
     series = CmsClient.get_series_by_id(id)
 

--- a/apps/crossroads_interface/web/controllers/legacy_controller.ex
+++ b/apps/crossroads_interface/web/controllers/legacy_controller.ex
@@ -25,12 +25,12 @@ defmodule CrossroadsInterface.LegacyController do
     end
   end
 
-  defp renderLegacyApp(conn, _params) do
+  defp renderLegacyApp(conn, params) do
     # when legacy app encounters a route it cannot serve, it sets cookie "unmatchedLegacyRoute" with value of that route
     if conn.cookies["unmatchedLegacyRoute"] != nil && URI.decode(conn.cookies["unmatchedLegacyRoute"]) == conn.request_path |> ContentHelpers.add_trailing_slash_if_necessary |> URI.decode do      
       conn 
       |> CrossroadsInterface.Plug.Cookie.call("unmatchedLegacyRoute", "") 
-      |> NotfoundController.notfound(_params)
+      |> NotfoundController.notfound(params)
     else    
       conn 
       |> CrossroadsInterface.Plug.Cookie.call("unmatchedLegacyRoute", "") 

--- a/apps/crossroads_interface/web/controllers/notfound_controller.ex
+++ b/apps/crossroads_interface/web/controllers/notfound_controller.ex
@@ -1,6 +1,5 @@
 defmodule CrossroadsInterface.NotfoundController do
   use CrossroadsInterface.Web, :controller
-  alias CrossroadsContent.CmsClient
 
   plug :put_layout, "no_sidebar.html"
   plug CrossroadsInterface.Plug.Meta

--- a/apps/crossroads_interface/web/templates/publications/_article_body.html.eex
+++ b/apps/crossroads_interface/web/templates/publications/_article_body.html.eex
@@ -48,7 +48,7 @@
                         <a href="<%= related["link"] %>">
                         <%= if related["thumbnail"] !== "" do %>
                             <img alt="Card image caption" class="card-img-top img-responsive" src="<%= related["thumbnail"] %>" title="" />
-                        <%= end %>
+                        <% end %>
                         </a>
                         <div class="card-block">
                             <a href="<%= related["link"] %>">
@@ -57,9 +57,9 @@
                             </a>
                         </div>
                     </div>
-                <%= end %>
+                <% end %>
             </div>
-            <%= end %>
+            <% end %>
         </div>
         <div class="row">
             <div class="col-md-6 col-md-offset-3">

--- a/apps/crossroads_interface/web/templates/publications/_publication_footer.html.eex
+++ b/apps/crossroads_interface/web/templates/publications/_publication_footer.html.eex
@@ -15,9 +15,9 @@
                         <p class="card-text"><a><%= more["author"] %></a> - <%= more["date"] %></p>
                     </div>
                 </div>
-            <%= end %>
+            <% end %>
             </div>
         </div>
     </div>
 </div>
-<%= end %>
+<% end %>

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "cachex": {:hex, :cachex, "2.1.0", "fad49b4e78d11c6c314e75bd8c9408f5b78cb065c047442798caed10803ee3be", [], [{:eternal, "~> 1.1", [hex: :eternal, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "credo": {:hex, :credo, "0.8.8", "990e7844a8d06ebacd88744a55853a83b74270b8a8461c55a4d0334b8e1736c9", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
@@ -34,4 +35,6 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [], [], "hexpm"},
+  "timex": {:hex, :timex, "3.2.1", "639975eac45c4c08c2dbf7fc53033c313ff1f94fad9282af03619a3826493612", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}


### PR DESCRIPTION
This PR fixes the output of many, _many_ warning messages about our code as a result of code being written that doesn't follow Elixir/Phoenix styleguide guidelines. All tests still pass and no functionality is changed.