### PR TITLE
DE5358 Add unit tests and fix bug

### DIFF
--- a/apps/crossroads_interface/test/plugs/fred_api_url_test.exs
+++ b/apps/crossroads_interface/test/plugs/fred_api_url_test.exs
@@ -1,0 +1,27 @@
+defmodule CrossroadsInterface.FredApiUrlPlugTest do
+  use CrossroadsInterface.ConnCase
+
+  test "given a blank environment var, the url should point to prod", %{conn: conn} do
+    Application.put_env(:crossroads_interface, :cookie_prefix, "")
+    conn = CrossroadsInterface.Plug.FredApiUrl.call(conn, "")
+    assert conn.assigns[:fred_api_url] == "https://api.crossroads.net"
+  end
+
+  test "given an environment var of int, the url should point to int", %{conn: conn} do
+    Application.put_env(:crossroads_interface, :cookie_prefix, "int")
+    conn = CrossroadsInterface.Plug.FredApiUrl.call(conn, "")
+    assert conn.assigns[:fred_api_url] == "https://api-int.crossroads.net"
+  end
+
+  test "given an environment var of demo, the url should point to demo", %{conn: conn} do
+    Application.put_env(:crossroads_interface, :cookie_prefix, "demo")
+    conn = CrossroadsInterface.Plug.FredApiUrl.call(conn, "")
+    assert conn.assigns[:fred_api_url] == "https://api-demo.crossroads.net"
+  end
+
+  test "given an environment var that is gibberish, the url should point to int", %{conn: conn} do
+    Application.put_env(:crossroads_interface, :cookie_prefix, "lsdf")
+    conn = CrossroadsInterface.Plug.FredApiUrl.call(conn, "")
+    assert conn.assigns[:fred_api_url] == "https://api-int.crossroads.net"
+  end
+end

--- a/apps/crossroads_interface/web/plugs/fred_api_url_plug.ex
+++ b/apps/crossroads_interface/web/plugs/fred_api_url_plug.ex
@@ -3,17 +3,18 @@ defmodule CrossroadsInterface.Plug.FredApiUrl do
   Determine the environment and build the fred API url.
   """
   import Plug.Conn
+  require IEx
 
-  def init(_default), do: "https://api-int.crossroads.net"
+  def init(default), do: default
 
-  def call(conn, default) do
-    :crossroads_interface
-    |> Application.get_env(:cookie_prefix, "")
-    |> case do
-      "int" -> assign(conn, :fred_api_url, default)
-      "demo" -> assign(conn, :fred_api_url, "https://api-demo.crossroads.net")
-      "" -> assign(conn, :fred_api_url, "https://api.crossroads.net")
-      _ -> assign(conn, :fred_api_url, default)
+  def call(conn, _default) do
+    environment = Application.get_env(:crossroads_interface, :cookie_prefix)
+    url = case environment do
+      "int" -> "https://api-int.crossroads.net"
+      "demo" -> "https://api-demo.crossroads.net"
+      "" -> "https://api.crossroads.net"
+      _ -> "https://api-int.crossroads.net"
     end
+    assign(conn, :fred_api_url, url)
   end
 end


### PR DESCRIPTION
This commit adds in unit tests and fixes a bug in the plug logic that
would set the int url, as well as the fallthrough url, to the second
argument of the plug call, resulting in a response that was not a valid
url.