### PR TITLE
[hotfix] Web Components and Shared Header

### DIFF
--- a/apps/crossroads_interface/web/static/js/dataTracker.js
+++ b/apps/crossroads_interface/web/static/js/dataTracker.js
@@ -8,15 +8,20 @@ CRDS.DataTracker = class DataTracker {
     this.clickTrackable = undefined;
     this.searchTrackable = undefined;
 
-    var int;
-    var waitForAnalytics = function() {
-      if(typeof analytics !== "undefined") {
-        clearInterval(int);
-        this.analytics = analytics;
-        this.init();
-      }
-    }.bind(this);
-    int = setInterval(function() { waitForAnalytics(); }, 100);
+    if(typeof analytics === "undefined") {
+      var int;
+      var waitForAnalytics = function() {
+        if(typeof analytics !== "undefined") {
+          clearInterval(int);
+          this.analytics = analytics;
+          this.init();
+        }
+      }.bind(this);
+      int = setInterval(function() { waitForAnalytics(); }, 100);
+    } else {
+      this.analytics = analytics;
+      this.init();
+    }
   }
 
   init() {

--- a/apps/crossroads_interface/web/static/js/dataTracker.js
+++ b/apps/crossroads_interface/web/static/js/dataTracker.js
@@ -7,8 +7,16 @@ CRDS.DataTracker = class DataTracker {
   constructor() {
     this.clickTrackable = undefined;
     this.searchTrackable = undefined;
-    this.analytics = analytics;
-    this.init();
+
+    var int;
+    var waitForAnalytics = function() {
+      if(typeof analytics !== "undefined") {
+        clearInterval(int);
+        this.analytics = analytics;
+        this.init();
+      }
+    }.bind(this);
+    int = setInterval(function() { waitForAnalytics(); }, 100);
   }
 
   init() {

--- a/apps/crossroads_interface/web/templates/shared/common_body.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_body.html.eex
@@ -22,6 +22,23 @@
           document.head.insertBefore(script, document.head.childNodes[0]);
         }
       });
+      window.addEventListener("DOMContentLoaded", function(event) {
+        if (document.querySelector('simple-fred') || document.querySelector('roll-call') || document.querySelector('livestream-reminder')) {
+          var script = document.createElement('script');
+          script.src = '//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.19/webcomponents-lite.js';
+          document.head.insertBefore(script, document.head.childNodes[0]);
+        }
+        if (document.querySelector('livestream-reminder')) {
+          var script = document.createElement('script');
+              script.src = '//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-livestream-reminder-v0.0.16.js';
+          document.head.insertBefore(script, document.head.childNodes[0]);
+        }
+        if (document.querySelector('roll-call')) {
+          var script = document.createElement('script');
+              script.src = '//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-rollcall-v0.1.0.js';
+          document.head.insertBefore(script, document.head.childNodes[0]);
+        }
+      });
     </script>
 
     <script src="https://use.fontawesome.com/ccd1aba2f7.js"></script>
@@ -34,10 +51,8 @@
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-card-carousel-v0.2.0.min.js"></script>
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-shared-header-v0.7.2.min.js"></script>
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-jumbotron-video-v0.2.0.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.19/webcomponents-lite.js"></script>
-    <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-livestream-reminder-v0.0.16.js" type="text/javascript"></script>
-    <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-rollcall-v0.1.0.js" type="text/javascript"></script>
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-status-message-v0.1.3.min.js"></script>
+
     <script>
       new CRDS.StatusMessage({ config: '//crossroads-assets.s3.amazonaws.com/browsers.json' });
       CRDS.JumbotronVideoPlayers = CRDS.JumbotronVideos;

--- a/apps/crossroads_interface/web/templates/shared/common_body.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/common_body.html.eex
@@ -32,7 +32,7 @@
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/svg4everybody/2.1.8/svg4everybody.min.js"></script>
     <script type="text/javascript" src="//cdn.jsdelivr.net/g/mutationobserver"></script>
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-card-carousel-v0.2.0.min.js"></script>
-    <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-shared-header-v0.6.2.min.js"></script>
+    <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-shared-header-v0.7.2.min.js"></script>
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-jumbotron-video-v0.2.0.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.19/webcomponents-lite.js"></script>
     <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-livestream-reminder-v0.0.16.js" type="text/javascript"></script>


### PR DESCRIPTION
This PR does two things... 

1). Bumps SharedHeader to its latest version to fix DE5374
2). Updates `common_body.html` to conditionally load web-components `<livestream-reminder>` and `<roll-call>` only when necessary.